### PR TITLE
Streamed HTTP body -> Z1/Z2/Z3 decoders, indexed framebuffer and ST7789 render

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,31 +286,37 @@ Tento repozitář nyní obsahuje inicializační firmware scaffold v C++ pro Pla
 5. Přidat NVS perzistenci do `config_manager` a STA/AP fallback režimy ve `wifi_manager`.
 6. Rozšířit scheduler o řízený fetch-render-sleep cyklus včetně deep sleep strategie.
 
-## 11. Milestone update: protocol-compatible network core (current step)
+## 11. Milestone update: stream decode + indexed framebuffer render (current step)
 
-Nově je ve scaffoldu implementováno:
+Nově je implementováno:
 
-- Reálné STA Wi-Fi připojení (`wifi_manager`) včetně blokujícího connect timeoutu, lightweight reconnect, RSSI/IP/MAC diagnostiky a počítadla retry pokusů.
-- První NVS perzistence přes `Preferences` v `config_manager` pro SSID, heslo, host, HTTPS mód, API key a poslední timestamp.
-- Stabilní 8místný numerický `X-API-Key` (vygenerování při prvním bootu, následné načítání ze storage).
-- Reálný HTTP/HTTPS POST tok v `protocol_compat`:
-  - `POST /index.php?timestampCheck=1`
-  - `Content-Type: application/json`
-  - `Connection: close`
-  - `X-API-Key`
-  - parsování status line + hlaviček (`Timestamp`, `PreciseSleep`, `Rotate`, `PartialRefresh`, `ShowNoWifiError`, `X-OTA-Update`)
-- Timestamp decision logika pro `timestampCheck=1` (same vs changed) s konzervativním režimem:
-  - nový timestamp je zatím jen kandidát,
-  - finální commit timestampu je odložen na fázi po úspěšném decode/render.
-- Scheduler nyní reálně periodicky polluje server (30 s) při dostupné Wi-Fi a aktualizuje runtime diagnostiku.
-- ST7789 status screen zobrazuje smysluplné běhové informace o Wi-Fi i poslední protokolové odpovědi.
+- Streamové předání HTTP body z `protocol_compat` do dekódovací pipeline přes `HttpBodyStream` bez ukládání celého payloadu do velkého `String` bufferu.
+- Tolerantní signaturový probe (okno až 4096 B) pro `PNG`, `Z1`, `Z2`, `Z3` v `image_decoder` s reportem formátu i offsetu signatury.
+- Interní `IndexedFramebuffer` (`uint8_t` indexy, contiguous storage, bounds-checked access) nezávislý na ST7789 driveru.
+- Dekódování formátů `Z1`, `Z2`, `Z3` do interního framebufferu (row-major), včetně robustního hlášení chyb:
+  - truncated stream
+  - zero-length run
+  - unsupported color index
+  - pixel overflow
+- `PNG` je nyní korektně rozpoznáno a vrací stav „recognized but not implemented yet“.
+- Render cesta z indexového framebufferu do ST7789:
+  - deterministické mapování barev 0..6 -> RGB565
+  - aplikace `Rotate` až ve fázi renderu
+  - `PartialRefresh` je propisováno jako hint (TODO pro další optimalizace)
+- Timestamp commit policy v scheduleru:
+  - beze změny timestampu: bez decode/render/commit
+  - při chybě decode/render: bez commit
+  - commit do NVS pouze po úspěšném decode + render
+- Rozšířená diagnostická obrazovka: Wi-Fi, API key, host, protocol status, detected format, signature offset, decode result, decoded pixels, stored/candidate timestamp, render result.
 
 ### Aktuální omezení
 
-- HTTP body je zatím pouze spočítáno (počet bajtů), ale ještě se nepředává do decoderu.
-- Není implementován image decoding (PNG/Z1/Z2/Z3), OTA download/execution, deep sleep ani AP provisioning.
-- Persistovaný `lastTimestamp` se zatím vědomě necommituje po detekci změny, aby se nezablokoval navazující image-fetch krok.
+- PNG dekodér není implementován (jen detekce + explicitní stav).
+- OTA download/execution, deep sleep politika, AP provisioning a web UI nejsou v tomto kroku implementovány.
+- Render běží jako full redraw (bez dirty-region optimalizace).
 
-### Doporučený další krok
+### Přesně doporučený další krok
 
-Implementovat přímé streamové předání HTTP body do `image_decoder` vrstvy + formátovou detekci, následně po úspěšném decode/render provést finální commit nového timestampu do `config_manager`.
+1. Přidat PNG dekodér do stejného `ImageDecoderFacade` kontraktu.
+2. Po stabilizaci PNG doplnit sleep policy (`PreciseSleep` + deep sleep) a navázat partial refresh optimalizace v render backendu.
+3. Následně řešit OTA execution flow s bezpečným rollbackem.

--- a/src/display/display_hal.h
+++ b/src/display/display_hal.h
@@ -2,9 +2,25 @@
 
 #include <Arduino.h>
 
+#include "image/indexed_framebuffer.h"
 #include "project_config.h"
 
 namespace zivyobraz::display {
+
+struct StatusSnapshot {
+  String fwVersion;
+  String wifiStatus;
+  String apiKey;
+  String serverHost;
+  String protocolStatus;
+  String detectedFormat;
+  String signatureOffset;
+  String decodeResult;
+  String pixelsDecoded;
+  String storedTimestamp;
+  String candidateTimestamp;
+  String renderResult;
+};
 
 class IDisplay {
  public:
@@ -12,8 +28,9 @@ class IDisplay {
   virtual bool begin(const DisplayConfig& cfg) = 0;
   virtual void clear(uint16_t color565) = 0;
   virtual void drawTestPattern() = 0;
-  virtual void drawStatusScreen(const String& fwVersion, const String& wifiStatus,
-                                const String& protocolStatus) = 0;
+  virtual void drawStatusScreen(const StatusSnapshot& status) = 0;
+  virtual bool renderIndexed(const image::IndexedFramebuffer& framebuffer, int8_t rotate,
+                             bool partialRefresh) = 0;
   virtual void setBacklight(bool on) = 0;
 };
 

--- a/src/display/st7789_display.cpp
+++ b/src/display/st7789_display.cpp
@@ -1,7 +1,7 @@
 #include "st7789_display.h"
 
-#include <memory>
 #include <SPI.h>
+#include <memory>
 
 #include "diagnostics/log.h"
 
@@ -45,30 +45,82 @@ void St7789Display::drawTestPattern() {
   tft_->fillRect(cfg_.width / 2, cfg_.height / 2, cfg_.width / 2, cfg_.height / 2, ST77XX_YELLOW);
 }
 
-void St7789Display::drawStatusScreen(const String& fwVersion, const String& wifiStatus,
-                                     const String& protocolStatus) {
+void St7789Display::drawStatusScreen(const StatusSnapshot& status) {
   if (!initialized_) {
     return;
   }
 
   tft_->fillScreen(ST77XX_BLACK);
   tft_->setTextColor(ST77XX_CYAN);
-  tft_->setTextSize(2);
-  tft_->setCursor(6, 6);
-  tft_->println("ZivyObraz");
-
-  tft_->setTextColor(ST77XX_WHITE);
   tft_->setTextSize(1);
-  tft_->setCursor(6, 30);
-  tft_->printf("FW: %s\n", fwVersion.c_str());
+  tft_->setCursor(2, 2);
+  tft_->printf("FW:%s", status.fwVersion.c_str());
 
   tft_->setTextColor(ST77XX_GREEN);
-  tft_->setCursor(6, 50);
-  tft_->println(wifiStatus);
+  tft_->setCursor(2, 16);
+  tft_->printf("WiFi:%s", status.wifiStatus.c_str());
+
+  tft_->setTextColor(ST77XX_WHITE);
+  tft_->setCursor(2, 30);
+  tft_->printf("API:%s", status.apiKey.c_str());
+  tft_->setCursor(2, 42);
+  tft_->printf("Host:%s", status.serverHost.c_str());
 
   tft_->setTextColor(ST77XX_YELLOW);
-  tft_->setCursor(6, 132);
-  tft_->println(protocolStatus);
+  tft_->setCursor(2, 56);
+  tft_->printf("Proto:%s", status.protocolStatus.c_str());
+  tft_->setCursor(2, 68);
+  tft_->printf("Fmt:%s off:%s", status.detectedFormat.c_str(), status.signatureOffset.c_str());
+
+  tft_->setTextColor(ST77XX_MAGENTA);
+  tft_->setCursor(2, 80);
+  tft_->printf("Decode:%s", status.decodeResult.c_str());
+  tft_->setCursor(2, 92);
+  tft_->printf("Pixels:%s", status.pixelsDecoded.c_str());
+
+  tft_->setTextColor(ST77XX_CYAN);
+  tft_->setCursor(2, 104);
+  tft_->printf("StoredTS:%s", status.storedTimestamp.c_str());
+  tft_->setCursor(2, 116);
+  tft_->printf("CandTS:%s", status.candidateTimestamp.c_str());
+
+  tft_->setTextColor(tft_->color565(255, 165, 0));
+  tft_->setCursor(2, 128);
+  tft_->printf("Render:%s", status.renderResult.c_str());
+}
+
+bool St7789Display::renderIndexed(const image::IndexedFramebuffer& framebuffer, int8_t rotate,
+                                  bool partialRefresh) {
+  if (!initialized_) {
+    return false;
+  }
+
+  (void)partialRefresh;  // TODO: use for backend-specific update optimization.
+  ZO_LOGI("Render begin: rotate=%d partialHint=%d", rotate, partialRefresh ? 1 : 0);
+  tft_->startWrite();
+
+  for (uint16_t y = 0; y < framebuffer.height(); ++y) {
+    for (uint16_t x = 0; x < framebuffer.width(); ++x) {
+      uint8_t index = 0;
+      if (!framebuffer.getPixel(x, y, index)) {
+        tft_->endWrite();
+        ZO_LOGE("Render failed: framebuffer read error");
+        return false;
+      }
+      uint16_t dstX = 0;
+      uint16_t dstY = 0;
+      if (!mapCoordinates(x, y, rotate, dstX, dstY)) {
+        tft_->endWrite();
+        ZO_LOGE("Render failed: invalid rotate=%d", rotate);
+        return false;
+      }
+      tft_->writePixel(dstX, dstY, mapColorIndex(index));
+    }
+  }
+
+  tft_->endWrite();
+  ZO_LOGI("Render end: ok");
+  return true;
 }
 
 void St7789Display::setBacklight(bool on) {
@@ -78,19 +130,56 @@ void St7789Display::setBacklight(bool on) {
   digitalWrite(cfg_.pins.bl, on ? HIGH : LOW);
 }
 
-void St7789Display::setPixel(uint16_t x, uint16_t y, uint16_t color565) {
-  if (!initialized_ || x >= cfg_.width || y >= cfg_.height) {
-    return;
+uint16_t St7789Display::mapColorIndex(uint8_t colorIndex) const {
+  switch (colorIndex) {
+    case 0:
+      return ST77XX_WHITE;
+    case 1:
+      return ST77XX_BLACK;
+    case 2:
+      return ST77XX_RED;
+    case 3:
+      return ST77XX_YELLOW;
+    case 4:
+      return ST77XX_GREEN;
+    case 5:
+      return ST77XX_BLUE;
+    case 6:
+      return tft_->color565(255, 165, 0);
+    default:
+      return ST77XX_BLACK;
   }
-  tft_->drawPixel(x, y, color565);
 }
 
-uint16_t St7789Display::width() const {
-  return cfg_.width;
-}
+bool St7789Display::mapCoordinates(uint16_t srcX, uint16_t srcY, int8_t rotate, uint16_t& outX,
+                                   uint16_t& outY) const {
+  if (srcX >= cfg_.width || srcY >= cfg_.height) {
+    return false;
+  }
 
-uint16_t St7789Display::height() const {
-  return cfg_.height;
+  switch (rotate) {
+    case 1:
+      outX = static_cast<uint16_t>(cfg_.width - 1 - srcY);
+      outY = srcX;
+      return true;
+    case 2:
+      outX = static_cast<uint16_t>(cfg_.width - 1 - srcX);
+      outY = static_cast<uint16_t>(cfg_.height - 1 - srcY);
+      return true;
+    case 3:
+      outX = srcY;
+      outY = static_cast<uint16_t>(cfg_.height - 1 - srcX);
+      return true;
+    case -1:
+    case 0:
+      outX = srcX;
+      outY = srcY;
+      return true;
+    default:
+      outX = srcX;
+      outY = srcY;
+      return false;
+  }
 }
 
 }  // namespace zivyobraz::display

--- a/src/display/st7789_display.h
+++ b/src/display/st7789_display.h
@@ -6,24 +6,24 @@
 #include <memory>
 
 #include "display_hal.h"
-#include "image/image_decoder.h"
 
 namespace zivyobraz::display {
 
-class St7789Display final : public IDisplay, public image::PixelSink {
+class St7789Display final : public IDisplay {
  public:
   bool begin(const DisplayConfig& cfg) override;
   void clear(uint16_t color565) override;
   void drawTestPattern() override;
-  void drawStatusScreen(const String& fwVersion, const String& wifiStatus,
-                        const String& protocolStatus) override;
+  void drawStatusScreen(const StatusSnapshot& status) override;
+  bool renderIndexed(const image::IndexedFramebuffer& framebuffer, int8_t rotate,
+                     bool partialRefresh) override;
   void setBacklight(bool on) override;
 
-  void setPixel(uint16_t x, uint16_t y, uint16_t color565) override;
-  uint16_t width() const override;
-  uint16_t height() const override;
-
  private:
+  uint16_t mapColorIndex(uint8_t colorIndex) const;
+  bool mapCoordinates(uint16_t srcX, uint16_t srcY, int8_t rotate, uint16_t& outX,
+                      uint16_t& outY) const;
+
   DisplayConfig cfg_{};
   std::unique_ptr<Adafruit_ST7789> tft_{};
   bool initialized_{false};

--- a/src/image/image_decoder.cpp
+++ b/src/image/image_decoder.cpp
@@ -1,36 +1,262 @@
 #include "image_decoder.h"
 
+#include <vector>
+
 #include "diagnostics/log.h"
 
 namespace zivyobraz::image {
 
-ImageFormat ImageDecoderFacade::detectFormat(const uint8_t* data, size_t len) const {
-  if (data == nullptr || len < 2) {
-    return ImageFormat::Unknown;
+namespace {
+constexpr uint8_t kPngSig0 = 0x89;
+constexpr uint8_t kPngSig1 = 0x50;
+
+struct ProbeResult {
+  ImageFormat format{ImageFormat::Unknown};
+  size_t signatureOffset{0};
+  std::vector<uint8_t> replayAfterSignature{};
+  size_t scannedBytes{0};
+  bool found{false};
+};
+
+class VectorReplayStream final : public IByteStream {
+ public:
+  VectorReplayStream(const std::vector<uint8_t>& data, IByteStream& fallback)
+      : data_(data), fallback_(fallback) {}
+
+  int readByte() override {
+    if (idx_ < data_.size()) {
+      return data_[idx_++];
+    }
+    return fallback_.readByte();
   }
 
-  if (len >= 8 && data[0] == 0x89 && data[1] == 0x50) {
-    return ImageFormat::Png;
-  }
+ private:
+  const std::vector<uint8_t>& data_;
+  IByteStream& fallback_;
+  size_t idx_{0};
+};
 
-  if (data[0] == 'Z' && data[1] == '1') {
-    return ImageFormat::Z1;
+bool isKnownSignature(uint8_t a, uint8_t b, ImageFormat& fmt) {
+  if (a == kPngSig0 && b == kPngSig1) {
+    fmt = ImageFormat::Png;
+    return true;
   }
-  if (data[0] == 'Z' && data[1] == '2') {
-    return ImageFormat::Z2;
+  if (a == 'Z' && b == '1') {
+    fmt = ImageFormat::Z1;
+    return true;
   }
-  if (data[0] == 'Z' && data[1] == '3') {
-    return ImageFormat::Z3;
+  if (a == 'Z' && b == '2') {
+    fmt = ImageFormat::Z2;
+    return true;
   }
-  return ImageFormat::Unknown;
+  if (a == 'Z' && b == '3') {
+    fmt = ImageFormat::Z3;
+    return true;
+  }
+  return false;
 }
 
-bool ImageDecoderFacade::decodeToSink(const uint8_t* data, size_t len, PixelSink& sink) {
-  (void)sink;
-  const ImageFormat fmt = detectFormat(data, len);
-  // TODO: dispatch to PNG/Z1/Z2/Z3 decoders.
-  ZO_LOGW("decodeToSink stub, detected format=%d", static_cast<int>(fmt));
-  return false;
+ProbeResult probeSignature(IByteStream& source, size_t probeLimit) {
+  ProbeResult result;
+  std::vector<uint8_t> scanned;
+  scanned.reserve(probeLimit);
+
+  while (scanned.size() < probeLimit) {
+    const int v = source.readByte();
+    if (v < 0) {
+      break;
+    }
+    scanned.push_back(static_cast<uint8_t>(v));
+    if (scanned.size() < 2) {
+      continue;
+    }
+
+    ImageFormat fmt = ImageFormat::Unknown;
+    if (isKnownSignature(scanned[scanned.size() - 2], scanned[scanned.size() - 1], fmt)) {
+      result.format = fmt;
+      result.signatureOffset = scanned.size() - 2;
+      result.found = true;
+      if (scanned.size() > result.signatureOffset + 2) {
+        result.replayAfterSignature.assign(scanned.begin() + result.signatureOffset + 2,
+                                           scanned.end());
+      }
+      break;
+    }
+  }
+
+  result.scannedBytes = scanned.size();
+  return result;
+}
+
+DecodeResult decodeRleRuns(IByteStream& source, IndexedFramebuffer& framebuffer, uint8_t colorShift,
+                           uint8_t countMask, uint8_t maxColor) {
+  DecodeResult result;
+  const size_t totalPixels = framebuffer.pixelCount();
+  size_t pixelPos = 0;
+
+  while (pixelPos < totalPixels) {
+    const int runValue = source.readByte();
+    if (runValue < 0) {
+      result.status = DecodeStatus::TruncatedData;
+      result.errorMessage = "Unexpected EOF in runs";
+      return result;
+    }
+    result.bytesConsumed++;
+
+    const uint8_t raw = static_cast<uint8_t>(runValue);
+    const uint8_t color = raw >> colorShift;
+    const uint8_t count = raw & countMask;
+
+    if (count == 0) {
+      result.status = DecodeStatus::InvalidData;
+      result.errorMessage = "Zero-length run";
+      return result;
+    }
+    if (color > maxColor) {
+      result.status = DecodeStatus::UnsupportedColor;
+      result.errorMessage = "Color index out of range";
+      return result;
+    }
+    if (pixelPos + count > totalPixels) {
+      result.status = DecodeStatus::Overflow;
+      result.errorMessage = "Run overflows framebuffer";
+      return result;
+    }
+
+    for (uint8_t i = 0; i < count; ++i) {
+      const uint16_t x = static_cast<uint16_t>(pixelPos % framebuffer.width());
+      const uint16_t y = static_cast<uint16_t>(pixelPos / framebuffer.width());
+      if (!framebuffer.setPixel(x, y, color)) {
+        result.status = DecodeStatus::FramebufferError;
+        result.errorMessage = "Failed to write framebuffer pixel";
+        return result;
+      }
+      pixelPos++;
+      result.pixelsDecoded++;
+    }
+  }
+
+  result.status = DecodeStatus::Ok;
+  result.success = true;
+  return result;
+}
+
+}  // namespace
+
+DecodeResult ImageDecoderFacade::decode(IByteStream& source, IndexedFramebuffer& framebuffer,
+                                        size_t probeLimit) const {
+  DecodeResult result;
+
+  const ProbeResult probe = probeSignature(source, probeLimit);
+  result.format = probe.format;
+  result.signatureOffset = probe.signatureOffset;
+
+  if (!probe.found) {
+    result.status = DecodeStatus::UnknownFormat;
+    result.errorMessage = "No supported signature in probe window";
+    ZO_LOGW("Signature probe failed after %u bytes", static_cast<unsigned int>(probe.scannedBytes));
+    return result;
+  }
+
+  ZO_LOGI("Signature probe: format=%d offset=%u scanned=%u", static_cast<int>(probe.format),
+          static_cast<unsigned int>(probe.signatureOffset),
+          static_cast<unsigned int>(probe.scannedBytes));
+
+  if (probe.format == ImageFormat::Png) {
+    result.status = DecodeStatus::RecognizedNotImplemented;
+    result.recognizedButNotImplemented = true;
+    result.errorMessage = "PNG recognized but not implemented yet";
+    return result;
+  }
+
+  VectorReplayStream decodeStream(probe.replayAfterSignature, source);
+
+  switch (probe.format) {
+    case ImageFormat::Z1:
+      result = decodeZ1(decodeStream, framebuffer);
+      break;
+    case ImageFormat::Z2:
+      result = decodeZ2(decodeStream, framebuffer);
+      break;
+    case ImageFormat::Z3:
+      result = decodeZ3(decodeStream, framebuffer);
+      break;
+    default:
+      result.status = DecodeStatus::UnknownFormat;
+      result.errorMessage = "No decoder available";
+      break;
+  }
+
+  result.format = probe.format;
+  result.signatureOffset = probe.signatureOffset;
+  return result;
+}
+
+DecodeResult ImageDecoderFacade::decodeZ1(IByteStream& source, IndexedFramebuffer& framebuffer) const {
+  DecodeResult result;
+  const size_t totalPixels = framebuffer.pixelCount();
+  size_t pixelPos = 0;
+
+  while (pixelPos < totalPixels) {
+    const int colorValue = source.readByte();
+    if (colorValue < 0) {
+      result.status = DecodeStatus::TruncatedData;
+      result.errorMessage = "Unexpected EOF in Z1 color";
+      return result;
+    }
+    const int countValue = source.readByte();
+    if (countValue < 0) {
+      result.status = DecodeStatus::TruncatedData;
+      result.errorMessage = "Unexpected EOF in Z1 count";
+      return result;
+    }
+    result.bytesConsumed += 2;
+
+    const uint8_t color = static_cast<uint8_t>(colorValue);
+    const uint8_t count = static_cast<uint8_t>(countValue);
+
+    if (count == 0) {
+      result.status = DecodeStatus::InvalidData;
+      result.errorMessage = "Zero-length run";
+      return result;
+    }
+    if (color > 6) {
+      result.status = DecodeStatus::UnsupportedColor;
+      result.errorMessage = "Color index out of range";
+      return result;
+    }
+    if (pixelPos + count > totalPixels) {
+      result.status = DecodeStatus::Overflow;
+      result.errorMessage = "Run overflows framebuffer";
+      return result;
+    }
+
+    for (uint8_t i = 0; i < count; ++i) {
+      const uint16_t x = static_cast<uint16_t>(pixelPos % framebuffer.width());
+      const uint16_t y = static_cast<uint16_t>(pixelPos / framebuffer.width());
+      if (!framebuffer.setPixel(x, y, color)) {
+        result.status = DecodeStatus::FramebufferError;
+        result.errorMessage = "Failed to write framebuffer pixel";
+        return result;
+      }
+      pixelPos++;
+      result.pixelsDecoded++;
+    }
+  }
+
+  result.status = DecodeStatus::Ok;
+  result.success = true;
+  return result;
+}
+
+DecodeResult ImageDecoderFacade::decodeZ2(IByteStream& source, IndexedFramebuffer& framebuffer) const {
+  DecodeResult result = decodeRleRuns(source, framebuffer, 6, 0x3F, 3);
+  return result;
+}
+
+DecodeResult ImageDecoderFacade::decodeZ3(IByteStream& source, IndexedFramebuffer& framebuffer) const {
+  DecodeResult result = decodeRleRuns(source, framebuffer, 5, 0x1F, 6);
+  return result;
 }
 
 }  // namespace zivyobraz::image

--- a/src/image/image_decoder.h
+++ b/src/image/image_decoder.h
@@ -2,6 +2,10 @@
 
 #include <Arduino.h>
 
+#include <vector>
+
+#include "indexed_framebuffer.h"
+
 namespace zivyobraz::image {
 
 enum class ImageFormat : uint8_t {
@@ -12,24 +16,42 @@ enum class ImageFormat : uint8_t {
   Z3,
 };
 
-struct PixelSink {
-  virtual ~PixelSink() = default;
-  virtual void setPixel(uint16_t x, uint16_t y, uint16_t color565) = 0;
-  virtual uint16_t width() const = 0;
-  virtual uint16_t height() const = 0;
+enum class DecodeStatus : uint8_t {
+  Ok,
+  UnknownFormat,
+  RecognizedNotImplemented,
+  InvalidData,
+  TruncatedData,
+  Overflow,
+  UnsupportedColor,
+  FramebufferError,
 };
 
-class IImageDecoder {
+class IByteStream {
  public:
-  virtual ~IImageDecoder() = default;
-  virtual ImageFormat format() const = 0;
-  virtual bool decode(const uint8_t* data, size_t len, PixelSink& sink) = 0;
+  virtual ~IByteStream() = default;
+  virtual int readByte() = 0;
+};
+
+struct DecodeResult {
+  ImageFormat format{ImageFormat::Unknown};
+  DecodeStatus status{DecodeStatus::UnknownFormat};
+  bool success{false};
+  bool recognizedButNotImplemented{false};
+  size_t signatureOffset{0};
+  size_t pixelsDecoded{0};
+  size_t bytesConsumed{0};
+  String errorMessage;
 };
 
 class ImageDecoderFacade {
  public:
-  ImageFormat detectFormat(const uint8_t* data, size_t len) const;
-  bool decodeToSink(const uint8_t* data, size_t len, PixelSink& sink);
+  DecodeResult decode(IByteStream& source, IndexedFramebuffer& framebuffer, size_t probeLimit) const;
+
+ private:
+  DecodeResult decodeZ1(IByteStream& source, IndexedFramebuffer& framebuffer) const;
+  DecodeResult decodeZ2(IByteStream& source, IndexedFramebuffer& framebuffer) const;
+  DecodeResult decodeZ3(IByteStream& source, IndexedFramebuffer& framebuffer) const;
 };
 
 }  // namespace zivyobraz::image

--- a/src/image/indexed_framebuffer.cpp
+++ b/src/image/indexed_framebuffer.cpp
@@ -1,0 +1,46 @@
+#include "indexed_framebuffer.h"
+
+#include <algorithm>
+
+namespace zivyobraz::image {
+
+bool IndexedFramebuffer::resize(uint16_t width, uint16_t height) {
+  width_ = width;
+  height_ = height;
+  pixels_.assign(static_cast<size_t>(width) * static_cast<size_t>(height), 0);
+  return pixels_.size() == pixelCount();
+}
+
+void IndexedFramebuffer::fill(uint8_t colorIndex) {
+  std::fill(pixels_.begin(), pixels_.end(), colorIndex);
+}
+
+bool IndexedFramebuffer::setPixel(uint16_t x, uint16_t y, uint8_t colorIndex) {
+  if (x >= width_ || y >= height_) {
+    return false;
+  }
+  pixels_[static_cast<size_t>(y) * width_ + x] = colorIndex;
+  return true;
+}
+
+bool IndexedFramebuffer::getPixel(uint16_t x, uint16_t y, uint8_t& colorIndex) const {
+  if (x >= width_ || y >= height_) {
+    return false;
+  }
+  colorIndex = pixels_[static_cast<size_t>(y) * width_ + x];
+  return true;
+}
+
+uint16_t IndexedFramebuffer::width() const {
+  return width_;
+}
+
+uint16_t IndexedFramebuffer::height() const {
+  return height_;
+}
+
+size_t IndexedFramebuffer::pixelCount() const {
+  return static_cast<size_t>(width_) * static_cast<size_t>(height_);
+}
+
+}  // namespace zivyobraz::image

--- a/src/image/indexed_framebuffer.h
+++ b/src/image/indexed_framebuffer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include <vector>
+
+namespace zivyobraz::image {
+
+class IndexedFramebuffer {
+ public:
+  bool resize(uint16_t width, uint16_t height);
+  void fill(uint8_t colorIndex);
+
+  bool setPixel(uint16_t x, uint16_t y, uint8_t colorIndex);
+  bool getPixel(uint16_t x, uint16_t y, uint8_t& colorIndex) const;
+
+  uint16_t width() const;
+  uint16_t height() const;
+  size_t pixelCount() const;
+
+ private:
+  uint16_t width_{0};
+  uint16_t height_{0};
+  std::vector<uint8_t> pixels_{};
+};
+
+}  // namespace zivyobraz::image

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,11 +35,10 @@ void setup() {
   if (!displayOk) {
     ZO_LOGE("Display init failed");
   } else {
-    gDisplay.drawStatusScreen(cfg.versions.fwVersion, gScheduler.wifiDiagnostics(),
-                              gScheduler.protocolDiagnostics());
+    gDisplay.drawStatusScreen(gScheduler.statusSnapshot());
   }
 
-  gScheduler.begin(&gConfig, &gWifi, &gProtocol);
+  gScheduler.begin(&gConfig, &gWifi, &gProtocol, &gDisplay);
   ZO_LOGI("Setup complete");
 }
 
@@ -49,8 +48,7 @@ void loop() {
   const uint32_t now = millis();
   if (now - gLastDisplayUpdateMs > 3000) {
     gLastDisplayUpdateMs = now;
-    gDisplay.drawStatusScreen(gConfig.get().versions.fwVersion, gScheduler.wifiDiagnostics(),
-                              gScheduler.protocolDiagnostics());
+    gDisplay.drawStatusScreen(gScheduler.statusSnapshot());
   }
 
   delay(10);

--- a/src/protocol/http_body_stream.cpp
+++ b/src/protocol/http_body_stream.cpp
@@ -1,0 +1,23 @@
+#include "http_body_stream.h"
+
+namespace zivyobraz::protocol {
+
+HttpBodyStream::HttpBodyStream(Client& client) : client_(client) {}
+
+int HttpBodyStream::readByte() {
+  while (!client_.available() && client_.connected()) {
+    delay(2);
+  }
+
+  const int value = client_.read();
+  if (value >= 0) {
+    bytesRead_++;
+  }
+  return value;
+}
+
+size_t HttpBodyStream::bytesRead() const {
+  return bytesRead_;
+}
+
+}  // namespace zivyobraz::protocol

--- a/src/protocol/http_body_stream.h
+++ b/src/protocol/http_body_stream.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Client.h>
+
+#include "image/image_decoder.h"
+
+namespace zivyobraz::protocol {
+
+class HttpBodyStream final : public image::IByteStream {
+ public:
+  explicit HttpBodyStream(Client& client);
+  int readByte() override;
+  size_t bytesRead() const;
+
+ private:
+  Client& client_;
+  size_t bytesRead_{0};
+};
+
+}  // namespace zivyobraz::protocol

--- a/src/protocol/protocol_compat.cpp
+++ b/src/protocol/protocol_compat.cpp
@@ -6,6 +6,7 @@
 
 #include "diagnostics/log.h"
 #include "project_config.h"
+#include "protocol/http_body_stream.h"
 
 namespace zivyobraz::protocol {
 
@@ -63,7 +64,8 @@ bool ProtocolCompatService::shouldFetchImage(const String& previousTimestamp,
 }
 
 ProtocolResponse ProtocolCompatService::performSync(bool timestampCheck, const String& apiKey,
-                                                    const String& previousTimestamp) {
+                                                    const String& previousTimestamp,
+                                                    const BodyHandler& bodyHandler) {
   ProtocolResponse rsp;
   rsp.previousTimestamp = previousTimestamp;
 
@@ -179,23 +181,30 @@ ProtocolResponse ProtocolCompatService::performSync(bool timestampCheck, const S
           rsp.headers.partialRefresh ? 1 : 0, rsp.headers.showNoWifiError ? 1 : 0,
           rsp.hasOtaUpdate ? 1 : 0);
 
-  // For this milestone we consume and count body bytes only.
-  // TODO: In the next milestone route this stream directly into format detection/decoder,
-  // and commit timestamp only after successful decode + display render.
+  HttpBodyStream bodyStream(*client);
+
+  if (rsp.httpOk && rsp.hasNewContent && bodyHandler) {
+    ZO_LOGI("HTTP body handoff to decoder pipeline");
+    rsp.bodyHandled = bodyHandler(bodyStream, rsp);
+  }
+
   while (client->available() || client->connected()) {
-    if (!client->available()) {
-      delay(5);
-      continue;
-    }
-    const int b = client->read();
+    const int b = bodyStream.readByte();
     if (b < 0) {
       break;
     }
-    rsp.bodySize++;
   }
+
+  rsp.bodySize = bodyStream.bytesRead();
   rsp.bodyPresent = rsp.bodySize > 0;
+  if (rsp.hasNewContent && !rsp.bodyPresent) {
+    rsp.status = TransportStatus::ProtocolError;
+    rsp.errorMessage = "Timestamp changed but body missing";
+  }
+
   client->stop();
-  ZO_LOGI("HTTP end: bodyBytes=%u", static_cast<unsigned int>(rsp.bodySize));
+  ZO_LOGI("HTTP end: bodyBytes=%u handled=%d", static_cast<unsigned int>(rsp.bodySize),
+          rsp.bodyHandled ? 1 : 0);
 
   return rsp;
 }

--- a/src/protocol/protocol_compat.h
+++ b/src/protocol/protocol_compat.h
@@ -3,15 +3,22 @@
 #include "project_config.h"
 #include "protocol_models.h"
 
+#include <functional>
+
+#include "image/image_decoder.h"
+
 namespace zivyobraz::protocol {
 
 class ProtocolCompatService {
  public:
+  using BodyHandler = std::function<bool(image::IByteStream& stream, ProtocolResponse& rsp)>;
+
   void begin(const RuntimeConfig& cfg);
   RequestMetadata buildMetadataPayload() const;
   bool shouldFetchImage(const String& previousTimestamp, const String& incomingTimestamp) const;
   ProtocolResponse performSync(bool timestampCheck, const String& apiKey,
-                               const String& previousTimestamp);
+                               const String& previousTimestamp,
+                               const BodyHandler& bodyHandler = nullptr);
 
  private:
   RuntimeConfig cfg_{};

--- a/src/protocol/protocol_models.h
+++ b/src/protocol/protocol_models.h
@@ -2,6 +2,8 @@
 
 #include <Arduino.h>
 
+#include "image/image_decoder.h"
+
 namespace zivyobraz::protocol {
 
 struct RequestMetadata {
@@ -34,6 +36,7 @@ enum class TransportStatus : uint8_t {
   NetworkError,
   HttpError,
   ParseError,
+  ProtocolError,
 };
 
 struct ProtocolResponse {
@@ -44,10 +47,14 @@ struct ProtocolResponse {
   bool bodyPresent{false};
   size_t bodySize{0};
   bool hasNewContent{false};
+  bool bodyHandled{false};
+  bool renderSuccess{false};
   String previousTimestamp;
   String candidateTimestamp;
   bool hasOtaUpdate{false};
   ResponseHeaders headers{};
+  image::DecodeResult decode{};
+  String renderMessage;
   String errorMessage;
 };
 

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -6,13 +6,15 @@ namespace zivyobraz::runtime {
 
 namespace {
 constexpr uint32_t kTickIntervalMs = 30000;
+constexpr size_t kProbeLimit = 4096;
 }
 
 void Scheduler::begin(config::ConfigManager* config, net::WifiManager* wifi,
-                      protocol::ProtocolCompatService* protocol) {
+                      protocol::ProtocolCompatService* protocol, display::IDisplay* display) {
   config_ = config;
   wifi_ = wifi;
   protocol_ = protocol;
+  display_ = display;
   state_ = SchedulerState::Idle;
   lastTickMs_ = 0;
 
@@ -46,17 +48,52 @@ void Scheduler::tick() {
   }
 
   state_ = SchedulerState::Sync;
-  lastProtocolResponse_ = protocol_->performSync(true, config_->apiKey(), config_->lastTimestamp());
+  image::ImageDecoderFacade decoder;
+  image::IndexedFramebuffer framebuffer;
+  framebuffer.resize(config_->get().display.width, config_->get().display.height);
 
-  if (!lastProtocolResponse_.candidateTimestamp.isEmpty()) {
-    if (lastProtocolResponse_.hasNewContent) {
-      ZO_LOGI("Timestamp changed: previous=%s candidate=%s", config_->lastTimestamp().c_str(),
-              lastProtocolResponse_.candidateTimestamp.c_str());
-      // Intentionally not persisted yet. The timestamp should be committed only after
-      // successful body decode and render in the next milestone.
+  lastProtocolResponse_ = protocol_->performSync(
+      true, config_->apiKey(), config_->lastTimestamp(),
+      [&](image::IByteStream& stream, protocol::ProtocolResponse& rsp) {
+        rsp.decode = decoder.decode(stream, framebuffer, kProbeLimit);
+        ZO_LOGI("Decode selected format=%d result=%d pixels=%u", static_cast<int>(rsp.decode.format),
+                static_cast<int>(rsp.decode.status), static_cast<unsigned int>(rsp.decode.pixelsDecoded));
+
+        if (!rsp.decode.success) {
+          return false;
+        }
+
+        if (display_ == nullptr) {
+          rsp.renderMessage = "Display unavailable";
+          return false;
+        }
+
+        const bool renderOk =
+            display_->renderIndexed(framebuffer, rsp.headers.rotate, rsp.headers.partialRefresh);
+        rsp.renderSuccess = renderOk;
+        rsp.renderMessage = renderOk ? "Render OK" : "Render failed";
+        return renderOk;
+      });
+
+  if (!lastProtocolResponse_.candidateTimestamp.isEmpty() && lastProtocolResponse_.hasNewContent) {
+    if (!lastProtocolResponse_.bodyPresent) {
+      ZO_LOGW("Timestamp not committed: body missing");
+      lastRenderResult_ = "No body";
+    } else if (!lastProtocolResponse_.decode.success || !lastProtocolResponse_.renderSuccess) {
+      ZO_LOGW("Timestamp not committed: decode/render failed");
+      lastRenderResult_ = lastProtocolResponse_.renderMessage;
+      if (lastRenderResult_.isEmpty()) {
+        lastRenderResult_ = lastProtocolResponse_.decode.errorMessage;
+      }
     } else {
-      ZO_LOGI("Timestamp unchanged: %s", lastProtocolResponse_.candidateTimestamp.c_str());
+      config_->setLastTimestamp(lastProtocolResponse_.candidateTimestamp);
+      config_->save();
+      ZO_LOGI("Timestamp committed: %s", lastProtocolResponse_.candidateTimestamp.c_str());
+      lastRenderResult_ = "Render OK + TS commit";
     }
+  } else if (!lastProtocolResponse_.candidateTimestamp.isEmpty()) {
+    ZO_LOGI("Timestamp unchanged: %s", lastProtocolResponse_.candidateTimestamp.c_str());
+    lastRenderResult_ = "Skipped (unchanged)";
   }
 
   state_ = SchedulerState::Idle;
@@ -64,51 +101,65 @@ void Scheduler::tick() {
 
 String Scheduler::wifiDiagnostics() const {
   if (wifi_ == nullptr) {
-    return "WiFi: n/a";
+    return "n/a";
   }
   String s;
-  s.reserve(160);
-  s += "WiFi: ";
+  s.reserve(64);
   s += wifi_->statusText();
-  s += "\nSSID: ";
-  s += wifi_->ssid();
-  s += "\nIP: ";
+  s += " ";
   s += wifi_->ip();
-  s += "\nRSSI: ";
-  s += String(wifi_->rssi());
-  s += " dBm";
-  s += "\nRetries: ";
-  s += String(wifi_->apRetries());
   return s;
 }
 
 String Scheduler::protocolDiagnostics() const {
   if (config_ == nullptr) {
-    return "Protocol: n/a";
+    return "n/a";
   }
 
-  String s;
-  s.reserve(280);
-  s += "API: ";
-  s += config_->apiKey();
-  s += "\nHost: ";
-  s += config_->get().server.host;
-  s += "\nHTTP: ";
   if (lastProtocolResponse_.status == protocol::TransportStatus::NotAttempted) {
-    s += "not attempted";
+    return "not attempted";
+  }
+
+  if (!lastProtocolResponse_.httpOk) {
+    return String(lastProtocolResponse_.httpStatusCode);
+  }
+  return "200 OK";
+}
+
+display::StatusSnapshot Scheduler::statusSnapshot() const {
+  display::StatusSnapshot s;
+  if (config_ == nullptr) {
     return s;
   }
 
-  s += lastProtocolResponse_.httpOk ? "200 OK" : String(lastProtocolResponse_.httpStatusCode);
-  s += "\nTS: ";
-  s += lastProtocolResponse_.headers.timestamp.isEmpty() ? "-" : lastProtocolResponse_.headers.timestamp;
-  s += "\nChanged: ";
-  s += lastProtocolResponse_.hasNewContent ? "yes" : "no";
-  s += "\nPreciseSleep: ";
-  s += String(lastProtocolResponse_.headers.preciseSleepSec);
-  s += "\nOTA: ";
-  s += lastProtocolResponse_.hasOtaUpdate ? "yes" : "no";
+  s.fwVersion = config_->get().versions.fwVersion;
+  s.wifiStatus = wifiDiagnostics();
+  s.apiKey = config_->apiKey();
+  s.serverHost = config_->get().server.host;
+  s.protocolStatus = protocolDiagnostics();
+  s.detectedFormat = formatName(lastProtocolResponse_.decode.format);
+  s.signatureOffset = String(lastProtocolResponse_.decode.signatureOffset);
+  s.decodeResult = lastProtocolResponse_.decode.success ? "OK" : lastProtocolResponse_.decode.errorMessage;
+  s.pixelsDecoded = String(lastProtocolResponse_.decode.pixelsDecoded);
+  s.storedTimestamp = config_->lastTimestamp();
+  s.candidateTimestamp = lastProtocolResponse_.candidateTimestamp;
+  s.renderResult = lastRenderResult_;
   return s;
+}
+
+String Scheduler::formatName(image::ImageFormat fmt) const {
+  switch (fmt) {
+    case image::ImageFormat::Png:
+      return "PNG";
+    case image::ImageFormat::Z1:
+      return "Z1";
+    case image::ImageFormat::Z2:
+      return "Z2";
+    case image::ImageFormat::Z3:
+      return "Z3";
+    default:
+      return "unknown";
+  }
 }
 
 }  // namespace zivyobraz::runtime

--- a/src/runtime/scheduler.h
+++ b/src/runtime/scheduler.h
@@ -3,6 +3,9 @@
 #include <Arduino.h>
 
 #include "config/config_manager.h"
+#include "display/display_hal.h"
+#include "image/image_decoder.h"
+#include "image/indexed_framebuffer.h"
 #include "net/wifi_manager.h"
 #include "protocol/protocol_compat.h"
 
@@ -17,19 +20,24 @@ enum class SchedulerState : uint8_t {
 class Scheduler {
  public:
   void begin(config::ConfigManager* config, net::WifiManager* wifi,
-             protocol::ProtocolCompatService* protocol);
+             protocol::ProtocolCompatService* protocol, display::IDisplay* display);
   void tick();
 
   String wifiDiagnostics() const;
   String protocolDiagnostics() const;
+  display::StatusSnapshot statusSnapshot() const;
 
  private:
+  String formatName(image::ImageFormat fmt) const;
+
   config::ConfigManager* config_{nullptr};
   net::WifiManager* wifi_{nullptr};
   protocol::ProtocolCompatService* protocol_{nullptr};
+  display::IDisplay* display_{nullptr};
   SchedulerState state_{SchedulerState::Idle};
   uint32_t lastTickMs_{0};
   protocol::ProtocolResponse lastProtocolResponse_{};
+  String lastRenderResult_{"n/a"};
 };
 
 }  // namespace zivyobraz::runtime


### PR DESCRIPTION
### Motivation

- Implement stream-oriented handoff from HTTP transport into the image decoding pipeline so payloads are not buffered into a giant `String` and decoders can operate incrementally.
- Add a tolerant signature probe (scan up to 4096 bytes) and support the Z1/Z2/Z3 formats (with PNG recognized but not implemented) to satisfy the Živý obraz protocol contract for this milestone.
- Provide an internal logical `IndexedFramebuffer` and a render path that maps logical color indices to the ST7789 display and only commit timestamps after successful decode+render.

### Description

- Added a stream adapter `HttpBodyStream` and a callback-style `BodyHandler` in `ProtocolCompatService::performSync(...)` so the protocol layer can hand the body stream to the decoder without buffering the entire payload; `ProtocolResponse` now carries decode/render metadata and protocol error states.
- Implemented `IndexedFramebuffer` (contiguous `uint8_t` indices, bounds-checked `setPixel`/`getPixel`, `resize`/`fill`) under `src/image/` to hold logical color indices independent of ST7789 APIs.
- Reworked the image decoder into `ImageDecoderFacade` that probes the first up-to-`4096` bytes for signatures (PNG, `Z1`, `Z2`, `Z3`) with noisy-prefix tolerance, reports signature offset, returns a structured `DecodeResult`, and implements Z1/Z2/Z3 decoders (robust EOF/overflow/invalid-run/color checks); PNG is recognized and returned as "recognized but not implemented yet".
- Implemented ST7789 render path that consumes the `IndexedFramebuffer` via `renderIndexed(...)`, applies `Rotate` at render time, maps indices `0..6` deterministically to RGB565, and accepts `PartialRefresh` as a plumbed hint (TODO for optimizations); expanded status snapshot API to surface diagnostics used by the status screen.
- Integrated decode+render into the scheduler so: unchanged timestamp = skip decode/render; changed timestamp triggers decode and render; timestamp is persisted only when both decode and render succeed; detailed logging added for probe/decoder/render/commit decisions.
- Updated `README.md` milestone section to describe implemented features, current limitations (PNG not implemented, OTA/sleep/web UI out of scope), and recommended next steps.

### Testing

- Attempted to run a local PlatformIO build via `pio run` and `platformio run`, but the PlatformIO CLI is not installed in this environment so the build could not be executed here (error: `command not found`).
- Changes were compiled-checked only via source edits and committed to the repo (commit message: "Implement streamed Z1/Z2/Z3 decode pipeline and indexed framebuffer render"); runtime/firmware validation is expected on-device or in CI with PlatformIO enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e10a32ec832297fd19b97da00af4)