### PR TITLE
Harden protocol request schema and API key preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,3 +341,19 @@ V tomto kroku byla doplněna cílená diagnostika protokolu (bez uvolnění prod
 ### Pravděpodobný další krok
 
 Porovnat skutečný wire dump (raw status/headers/body preview) s očekávaným serverovým kontraktem a potvrdit, zda problém vzniká na straně serverové odpovědi nebo ve formátu hlaviček/flow režimu `timestampCheck`.
+
+## 13. Milestone update: request schema hardening + API key preflight
+
+V tomto kroku byl zpřísněn request kontrakt směrem k serverovému protokolu:
+
+- Payload `board` je nyní posílán jako skalární string (ne jako objekt).
+- `network.ip` byl nahrazen `network.ipAddress` a payload obsahuje i `network.apRetries`.
+- `display` metadata jsou rozšířena na `type`, `width`, `height`, `colorType` (pro ST7789 nyní `"7C"`).
+- `system` již neposílá nekompatibilní `name`; posílají se jen protokolově kompatibilní pole (aktuálně `resetReason`, pokud je k dispozici).
+- API key lifecycle byl zpřesněn:
+  - validace přesně 8 číslic,
+  - při chybě/missing stavu regenerace + persistence,
+  - jasné logování, zda byl key načten nebo regenerován.
+- Přidána preflight validace requestu před odesláním (`apiKey`, `board`, `network.ipAddress`, `display.width/height/colorType`).
+  - Při validační chybě se request neodešle.
+- Wire debug log nově obsahuje kompaktní schema summary (`boardKind`, `systemFields`, `networkFields`, `displayFields`, `apiKeyValid`).

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -19,6 +19,12 @@ constexpr const char* kKeyLastTs = "last_ts";
 void ConfigManager::begin() {
   loadDefaults();
   load();
+
+  if (!isValidApiKey(cfg_.apiKey)) {
+    cfg_.apiKey = generateApiKey();
+    ZO_LOGW("API key invalid or missing after load; regenerated: %s", cfg_.apiKey.c_str());
+    save();
+  }
 }
 
 const RuntimeConfig& ConfigManager::get() const {
@@ -40,9 +46,11 @@ bool ConfigManager::load() {
   cfg_.lastTimestamp = prefs.getString(kKeyLastTs, "");
   prefs.end();
 
-  if (!isValidApiKey(cfg_.apiKey)) {
+  if (isValidApiKey(cfg_.apiKey)) {
+    ZO_LOGI("API key loaded from NVS: %s", cfg_.apiKey.c_str());
+  } else {
     cfg_.apiKey = generateApiKey();
-    ZO_LOGI("Generated new API key: %s", cfg_.apiKey.c_str());
+    ZO_LOGW("API key missing/invalid in NVS; regenerated: %s", cfg_.apiKey.c_str());
     save();
   }
 

--- a/src/protocol/protocol_compat.cpp
+++ b/src/protocol/protocol_compat.cpp
@@ -6,6 +6,8 @@
 
 #include <vector>
 
+#include <esp_system.h>
+
 #include "diagnostics/log.h"
 #include "project_config.h"
 #include "protocol/http_body_stream.h"
@@ -106,14 +108,15 @@ RequestMetadata ProtocolCompatService::buildMetadataPayload() const {
   payload.apiVersion = cfg_.versions.apiVersion;
   payload.buildDate = ZO_BUILD_DATE;
   payload.board = cfg_.boardName;
-  payload.system = "esp32-arduino";
-  payload.network = "wifi";
-  payload.display = "st7789-240x240";
-  payload.sensors = "";
+  payload.systemResetReason = String(esp_reset_reason());
   payload.wifiSsid = WiFi.SSID();
-  payload.localIp = WiFi.localIP().toString();
+  payload.ipAddress = WiFi.localIP().toString();
   payload.mac = WiFi.macAddress();
   payload.rssi = WiFi.RSSI();
+  payload.displayType = "st7789";
+  payload.displayWidth = cfg_.display.width;
+  payload.displayHeight = cfg_.display.height;
+  payload.displayColorType = "7C";
   return payload;
 }
 
@@ -126,7 +129,7 @@ bool ProtocolCompatService::shouldFetchImage(const String& previousTimestamp,
 }
 
 ProtocolResponse ProtocolCompatService::performSync(bool timestampCheck, const String& apiKey,
-                                                    const String& previousTimestamp,
+                                                    const String& previousTimestamp, uint32_t apRetries,
                                                     const BodyHandler& bodyHandler) {
   ProtocolResponse rsp;
   rsp.previousTimestamp = previousTimestamp;
@@ -140,11 +143,32 @@ ProtocolResponse ProtocolCompatService::performSync(bool timestampCheck, const S
   }
 
   RequestMetadata metadata = buildMetadataPayload();
+  metadata.apRetries = apRetries;
+
+  String validationError;
+  if (!validateRequestMetadata(metadata, apiKey, validationError)) {
+    rsp.status = TransportStatus::ProtocolError;
+    rsp.resultClass = ProtocolResultClass::ProtocolRequestInvalid;
+    rsp.errorMessage = validationError;
+    ZO_LOGE("Request validation failed: %s", validationError.c_str());
+    return rsp;
+  }
+
   const String body = buildMetadataJson(metadata);
   const String path = cfg_.server.endpointPath + "?timestampCheck=" + String(timestampCheck ? 1 : 0);
   const uint16_t port = cfg_.server.useHttps ? 443 : 80;
 
   if (wireDebugEnabled()) {
+    std::vector<String> systemFields;
+    if (!metadata.systemResetReason.isEmpty()) {
+      systemFields.push_back("resetReason");
+    }
+    std::vector<String> networkFields{"ssid", "rssi", "mac", "apRetries", "ipAddress"};
+    std::vector<String> displayFields{"type", "width", "height", "colorType"};
+
+    ZO_LOGI("[WireDbg] Request schema boardKind=string systemFields=%s networkFields=%s displayFields=%s apiKeyValid=%s",
+            joinFieldList(systemFields).c_str(), joinFieldList(networkFields).c_str(),
+            joinFieldList(displayFields).c_str(), (apiKey.length() == 8) ? "yes" : "no");
     ZO_LOGI("[WireDbg] Request transport=%s host=%s path=%s contentLength=%u apiKey=%s timestampCheck=%d",
             cfg_.server.useHttps ? "https" : "http", cfg_.server.host.c_str(), path.c_str(),
             static_cast<unsigned int>(body.length()), apiKey.c_str(), timestampCheck ? 1 : 0);
@@ -364,23 +388,85 @@ ProtocolResponse ProtocolCompatService::performSync(bool timestampCheck, const S
 
 String ProtocolCompatService::buildMetadataJson(const RequestMetadata& md) const {
   String json;
-  json.reserve(512);
+  json.reserve(640);
   json += "{";
   json += "\"fwVersion\":\"" + jsonEscape(md.fwVersion) + "\",";
   json += "\"apiVersion\":\"" + jsonEscape(md.apiVersion) + "\",";
   json += "\"buildDate\":\"" + jsonEscape(md.buildDate) + "\",";
-  json += "\"board\":{\"name\":\"" + jsonEscape(md.board) + "\"},";
-  json += "\"system\":{\"name\":\"" + jsonEscape(md.system) + "\"},";
-  json += "\"network\":{";
-  json += "\"type\":\"" + jsonEscape(md.network) + "\",";
-  json += "\"ssid\":\"" + jsonEscape(md.wifiSsid) + "\",";
-  json += "\"ip\":\"" + jsonEscape(md.localIp) + "\",";
-  json += "\"mac\":\"" + jsonEscape(md.mac) + "\",";
-  json += "\"rssi\":" + String(md.rssi);
+  json += "\"board\":\"" + jsonEscape(md.board) + "\",";
+
+  json += "\"system\":{";
+  if (!md.systemResetReason.isEmpty()) {
+    json += "\"resetReason\":\"" + jsonEscape(md.systemResetReason) + "\"";
+  }
   json += "},";
-  json += "\"display\":{\"type\":\"" + jsonEscape(md.display) + "\"}";
+
+  json += "\"network\":{";
+  json += "\"ssid\":\"" + jsonEscape(md.wifiSsid) + "\",";
+  json += "\"rssi\":" + String(md.rssi) + ",";
+  json += "\"mac\":\"" + jsonEscape(md.mac) + "\",";
+  json += "\"apRetries\":" + String(md.apRetries) + ",";
+  json += "\"ipAddress\":\"" + jsonEscape(md.ipAddress) + "\"";
+  json += "},";
+
+  json += "\"display\":{";
+  json += "\"type\":\"" + jsonEscape(md.displayType) + "\",";
+  json += "\"width\":" + String(md.displayWidth) + ",";
+  json += "\"height\":" + String(md.displayHeight) + ",";
+  json += "\"colorType\":\"" + jsonEscape(md.displayColorType) + "\"";
+  json += "}";
+
   json += "}";
   return json;
+}
+
+bool ProtocolCompatService::validateRequestMetadata(const RequestMetadata& md, const String& apiKey,
+                                                    String& validationError) const {
+  if (apiKey.length() != 8) {
+    validationError = "Invalid API key: must be 8 digits";
+    return false;
+  }
+  for (size_t i = 0; i < apiKey.length(); ++i) {
+    if (!isDigit(apiKey[i])) {
+      validationError = "Invalid API key: non-digit character";
+      return false;
+    }
+  }
+  if (md.board.isEmpty()) {
+    validationError = "Invalid request metadata: board is empty";
+    return false;
+  }
+  if (WiFi.status() == WL_CONNECTED && md.ipAddress.isEmpty()) {
+    validationError = "Invalid request metadata: network.ipAddress is empty";
+    return false;
+  }
+  if (md.displayWidth == 0) {
+    validationError = "Invalid request metadata: display.width must be > 0";
+    return false;
+  }
+  if (md.displayHeight == 0) {
+    validationError = "Invalid request metadata: display.height must be > 0";
+    return false;
+  }
+  if (md.displayColorType.isEmpty()) {
+    validationError = "Invalid request metadata: display.colorType is empty";
+    return false;
+  }
+  return true;
+}
+
+String ProtocolCompatService::joinFieldList(const std::vector<String>& fields) const {
+  if (fields.empty()) {
+    return "none";
+  }
+  String out;
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (i > 0) {
+      out += ",";
+    }
+    out += fields[i];
+  }
+  return out;
 }
 
 bool ProtocolCompatService::parseBoolHeaderValue(String value) const {

--- a/src/protocol/protocol_compat.h
+++ b/src/protocol/protocol_compat.h
@@ -4,6 +4,7 @@
 #include "protocol_models.h"
 
 #include <functional>
+#include <vector>
 
 #include "image/image_decoder.h"
 
@@ -17,12 +18,15 @@ class ProtocolCompatService {
   RequestMetadata buildMetadataPayload() const;
   bool shouldFetchImage(const String& previousTimestamp, const String& incomingTimestamp) const;
   ProtocolResponse performSync(bool timestampCheck, const String& apiKey,
-                               const String& previousTimestamp,
+                               const String& previousTimestamp, uint32_t apRetries,
                                const BodyHandler& bodyHandler = nullptr);
 
  private:
   RuntimeConfig cfg_{};
   String buildMetadataJson(const RequestMetadata& md) const;
+  bool validateRequestMetadata(const RequestMetadata& md, const String& apiKey,
+                               String& validationError) const;
+  String joinFieldList(const std::vector<String>& fields) const;
   bool parseBoolHeaderValue(String value) const;
   bool wireDebugEnabled() const;
   BodyProbeKind probeBodySignature(const uint8_t* data, size_t len, int32_t& offset) const;

--- a/src/protocol/protocol_models.h
+++ b/src/protocol/protocol_models.h
@@ -11,14 +11,16 @@ struct RequestMetadata {
   String apiVersion;
   String buildDate;
   String board;
-  String system;
-  String network;
-  String display;
-  String sensors;
+  String systemResetReason;
   String wifiSsid;
-  String localIp;
+  String ipAddress;
   String mac;
   int32_t rssi{0};
+  uint32_t apRetries{0};
+  String displayType;
+  uint16_t displayWidth{0};
+  uint16_t displayHeight{0};
+  String displayColorType;
 };
 
 struct ResponseHeaders {
@@ -51,6 +53,7 @@ enum class ProtocolResultClass : uint8_t {
   ProtocolMissingTimestamp,
   ProtocolBodyMissing,
   ProtocolDecodeRenderFailure,
+  ProtocolRequestInvalid,
 };
 
 enum class TransportStatus : uint8_t {

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -61,7 +61,7 @@ void Scheduler::tick() {
   }
 
   lastProtocolResponse_ = protocol_->performSync(
-      timestampCheck, config_->apiKey(), config_->lastTimestamp(),
+      timestampCheck, config_->apiKey(), config_->lastTimestamp(), wifi_->apRetries(),
       [&](image::IByteStream& stream, protocol::ProtocolResponse& rsp) {
         rsp.decode = decoder.decode(stream, framebuffer, kProbeLimit);
         ZO_LOGI("Decode selected format=%d result=%d pixels=%u", static_cast<int>(rsp.decode.format),
@@ -138,6 +138,9 @@ String Scheduler::protocolDiagnostics() const {
   }
 
   String s = String(lastProtocolResponse_.httpStatusCode) + " " + resultClassName(lastProtocolResponse_.resultClass);
+  if (!lastProtocolResponse_.errorMessage.isEmpty()) {
+    s += " (" + lastProtocolResponse_.errorMessage + ")";
+  }
   return s;
 }
 
@@ -199,6 +202,8 @@ String Scheduler::resultClassName(protocol::ProtocolResultClass rc) const {
       return "missing_body";
     case protocol::ProtocolResultClass::ProtocolDecodeRenderFailure:
       return "decode_render";
+    case protocol::ProtocolResultClass::ProtocolRequestInvalid:
+      return "request_invalid";
     default:
       return "unknown";
   }


### PR DESCRIPTION
### Motivation
- Server-side errors indicated the sent JSON did not match the expected schema (e.g. `mysqli_real_escape_string()` receiving an array), so the request payload must be strictly shaped to the documented contract.
- The device was sending `board` as an object and `network.ip` / `display` as incompatible fields, causing protocol mismatch with the server.
- `X-API-Key` was observed empty in logs, so API key loading/validation/persistence must be hardened to guarantee a stable 8-digit numeric key.

### Description
- Aligned request model: updated `RequestMetadata` to carry `ipAddress`, `apRetries`, `displayType`, `displayWidth`, `displayHeight`, `displayColorType`, and `systemResetReason` (files: `src/protocol/protocol_models.h`).
- Reworked metadata builder and JSON output so `board` is emitted as a scalar string and payload uses `system.resetReason`, `network.ipAddress`, `network.apRetries`, and `display.{type,width,height,colorType}` (files: `src/protocol/protocol_compat.cpp`, `src/protocol/protocol_compat.h`).
- Added preflight validation via `validateRequestMetadata()` to block malformed requests (checks: API key 8-digit numeric, non-empty `board`, `network.ipAddress` when connected, `display.width`/`height` > 0, non-empty `display.colorType`) and added a compact wire-debug schema summary via `joinFieldList()` (file: `src/protocol/protocol_compat.cpp`).
- Hardened API key lifecycle: validate on load/begin, regenerate and persist when missing/invalid, and log whether the key was loaded or regenerated (file: `src/config/config_manager.cpp`).
- Propagated `apRetries` from `WifiManager` into the protocol sync call and surfaced protocol error details in scheduler diagnostics without modifying response parsing, decoding, rendering, or timestamp commit logic (file: `src/runtime/scheduler.cpp`).
- Documentation: added a README milestone note describing the schema hardening, API key preflight, and wire debug summary (file: `README.md`).

### Testing
- Attempted to run a full build with `platformio run`, but the runtime environment lacks PlatformIO (error: `platformio: command not found`), so no binary was produced.
- Attempted `pio run` as an alternative, which also failed with `pio: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1efe72e4083228e05bc5f852eb138)