### PR TITLE
Add captive portal AP fallback for Wi‑Fi provisioning

### DIFF
--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -95,6 +95,12 @@ void ConfigManager::setLastTimestamp(const String& timestamp) {
 }
 
 bool ConfigManager::setWifi(const String& ssid, const String& password) {
+  if (ssid.isEmpty() || ssid.length() > 32 || password.length() > 64) {
+    ZO_LOGW("ConfigManager: invalid WiFi config (ssid length=%u, pass length=%u)",
+            static_cast<unsigned>(ssid.length()), static_cast<unsigned>(password.length()));
+    return false;
+  }
+
   cfg_.wifi.ssid = ssid;
   // An empty password string means "keep the existing one" to avoid
   // accidentally wiping credentials when only the SSID is changed.

--- a/src/display/display_hal.h
+++ b/src/display/display_hal.h
@@ -10,6 +10,9 @@ namespace zivyobraz::display {
 struct StatusSnapshot {
   String fwVersion;
   String wifiStatus;
+  String wifiApSsid;
+  String wifiPortalIp;
+  String wifiApPassword;
   String apiKey;
   String serverHost;
   String protocolStatus;

--- a/src/display/st7789_display.cpp
+++ b/src/display/st7789_display.cpp
@@ -60,6 +60,25 @@ void St7789Display::drawStatusScreen(const StatusSnapshot& status) {
   tft_->setCursor(2, 14);
   tft_->printf("WiFi:%s", status.wifiStatus.c_str());
 
+  if (!status.wifiApSsid.isEmpty()) {
+    tft_->setTextColor(ST77XX_YELLOW);
+    tft_->setCursor(2, 26);
+    tft_->printf("CONFIG REZIM");
+    tft_->setCursor(2, 38);
+    tft_->printf("AP:%s", status.wifiApSsid.c_str());
+    tft_->setCursor(2, 50);
+    tft_->printf("PASS:%s", status.wifiApPassword.c_str());
+    tft_->setCursor(2, 62);
+    tft_->printf("IP:%s", status.wifiPortalIp.c_str());
+    tft_->setCursor(2, 74);
+    tft_->printf("1) Pripojit WiFi");
+    tft_->setCursor(2, 86);
+    tft_->printf("2) Otevrit portal");
+    tft_->setCursor(2, 98);
+    tft_->printf("3) Nastavit domaci");
+    return;
+  }
+
   tft_->setTextColor(ST77XX_WHITE);
   tft_->setCursor(2, 26);
   tft_->printf("API:%s", status.apiKey.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ void setup() {
 
   zivyobraz::core::logBootBanner(cfg.boardName);
 
-  gWifi.begin(cfg.wifi);
+  gWifi.begin(cfg.wifi, cfg.boardName);
   gProtocol.begin(cfg);
 
   const bool displayOk = gDisplay.begin(cfg.display);

--- a/src/net/wifi_manager.cpp
+++ b/src/net/wifi_manager.cpp
@@ -8,27 +8,43 @@ namespace zivyobraz::net {
 
 namespace {
 constexpr uint32_t kReconnectIntervalMs = 10000;
+constexpr uint8_t kDnsPort = 53;
+constexpr char kDefaultApPassword[] = "zivyobraz-setup";
 }
 
-void WifiManager::begin(const WifiConfig& cfg) {
+void WifiManager::begin(const WifiConfig& cfg, const String& deviceName) {
   cfg_ = cfg;
+  deviceName_ = deviceName;
   apRetries_ = 0;
-  WiFi.mode(WIFI_STA);
-  WiFi.setAutoReconnect(true);
+  portalActive_ = false;
+  apSsid_ = buildApSsid();
+  apPassword_ = String(kDefaultApPassword);
+
   WiFi.persistent(false);
+  WiFi.setAutoReconnect(true);
+  WiFi.mode(WIFI_STA);
 
   if (cfg_.ssid.isEmpty()) {
-    state_ = WifiState::NotConfigured;
-    ZO_LOGW("Wi-Fi not configured (empty SSID)");
+    state_ = WifiState::Unconfigured;
+    ZO_LOGW("Wi-Fi config missing (empty SSID), starting captive AP mode");
+    startApPortal();
     return;
   }
 
-  state_ = WifiState::Disconnected;
+  state_ = WifiState::Connecting;
   ZO_LOGI("WifiManager initialized, ssid='%s'", cfg_.ssid.c_str());
+  if (!connect(12000)) {
+    ZO_LOGW("Initial STA connect failed, switching to captive AP mode");
+    startApPortal();
+  }
 }
 
 void WifiManager::tick() {
-  if (state_ == WifiState::NotConfigured) {
+  if (portalActive_) {
+    dnsServer_.processNextRequest();
+  }
+
+  if (WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA) {
     return;
   }
 
@@ -37,8 +53,17 @@ void WifiManager::tick() {
     return;
   }
 
-  state_ = WifiState::Disconnected;
+  if (cfg_.ssid.isEmpty()) {
+    state_ = WifiState::Unconfigured;
+    startApPortal();
+    return;
+  }
+
   const uint32_t now = millis();
+  if (state_ == WifiState::ConnectFailed && now - lastReconnectAttemptMs_ < kReconnectIntervalMs) {
+    return;
+  }
+
   if (now - lastReconnectAttemptMs_ >= kReconnectIntervalMs) {
     lastReconnectAttemptMs_ = now;
     reconnect();
@@ -47,11 +72,12 @@ void WifiManager::tick() {
 
 bool WifiManager::connect(uint32_t timeoutMs) {
   if (cfg_.ssid.isEmpty()) {
-    state_ = WifiState::NotConfigured;
+    state_ = WifiState::Unconfigured;
     return false;
   }
 
   if (WiFi.status() == WL_CONNECTED) {
+    stopApPortal();
     state_ = WifiState::Connected;
     return true;
   }
@@ -61,36 +87,67 @@ bool WifiManager::connect(uint32_t timeoutMs) {
   ZO_LOGI("Wi-Fi connecting attempt #%lu to SSID '%s'", static_cast<unsigned long>(apRetries_),
           cfg_.ssid.c_str());
 
+  WiFi.mode(WIFI_STA);
   WiFi.begin(cfg_.ssid.c_str(), cfg_.password.c_str());
 
   const uint32_t start = millis();
   while (millis() - start < timeoutMs) {
     if (WiFi.status() == WL_CONNECTED) {
+      stopApPortal();
       state_ = WifiState::Connected;
       ZO_LOGI("Wi-Fi connected: ip=%s rssi=%ld mac=%s", ip().c_str(), static_cast<long>(rssi()),
               mac().c_str());
       return true;
     }
     delay(250);
+    if (portalActive_) {
+      dnsServer_.processNextRequest();
+    }
   }
 
-  state_ = WifiState::Disconnected;
+  state_ = WifiState::ConnectFailed;
   ZO_LOGW("Wi-Fi connect timeout after %lu ms", static_cast<unsigned long>(timeoutMs));
   return false;
 }
 
 bool WifiManager::reconnect(uint32_t timeoutMs) {
-  if (state_ == WifiState::NotConfigured) {
+  if (cfg_.ssid.isEmpty()) {
+    state_ = WifiState::Unconfigured;
     return false;
   }
   ZO_LOGI("Wi-Fi reconnect requested");
   WiFi.disconnect(false, false);
-  return connect(timeoutMs);
+  const bool ok = connect(timeoutMs);
+  if (!ok && !portalActive_) {
+    startApPortal();
+  }
+  return ok;
 }
 
 void WifiManager::disconnect() {
   WiFi.disconnect(false, false);
-  state_ = WifiState::Disconnected;
+  stopApPortal();
+  state_ = WifiState::ConnectFailed;
+}
+
+bool WifiManager::applyConfigAndConnect(const WifiConfig& cfg, uint32_t timeoutMs) {
+  cfg_ = cfg;
+  if (cfg_.ssid.isEmpty()) {
+    ZO_LOGW("Cannot apply Wi-Fi config: empty SSID");
+    state_ = WifiState::Unconfigured;
+    startApPortal();
+    return false;
+  }
+
+  ZO_LOGI("Applying new Wi-Fi configuration for SSID '%s'", cfg_.ssid.c_str());
+  const bool ok = reconnect(timeoutMs);
+  if (ok) {
+    ZO_LOGI("New Wi-Fi configuration connected successfully");
+  } else {
+    ZO_LOGW("New Wi-Fi configuration failed, AP portal remains active");
+    startApPortal();
+  }
+  return ok;
 }
 
 WifiState WifiManager::state() const {
@@ -103,13 +160,15 @@ String WifiManager::statusText() const {
       return "connected";
     case WifiState::Connecting:
       return "connecting";
-    case WifiState::NotConfigured:
-      return "not configured";
-    case WifiState::ApFallback:
-      return "ap-fallback";
-    case WifiState::Disconnected:
+    case WifiState::Unconfigured:
+      return "unconfigured";
+    case WifiState::ApMode:
+      return "ap-mode";
+    case WifiState::PortalActive:
+      return "portal-active";
+    case WifiState::ConnectFailed:
     default:
-      return "disconnected";
+      return "connect-failed";
   }
 }
 
@@ -118,10 +177,13 @@ String WifiManager::ssid() const {
 }
 
 String WifiManager::ip() const {
-  if (WiFi.status() != WL_CONNECTED) {
-    return "-";
+  if (WiFi.status() == WL_CONNECTED) {
+    return WiFi.localIP().toString();
   }
-  return WiFi.localIP().toString();
+  if (portalActive_) {
+    return apIp_.toString();
+  }
+  return "-";
 }
 
 String WifiManager::mac() const {
@@ -141,6 +203,84 @@ uint32_t WifiManager::apRetries() const {
 
 bool WifiManager::isConnected() const {
   return WiFi.status() == WL_CONNECTED;
+}
+
+bool WifiManager::isPortalActive() const {
+  return portalActive_;
+}
+
+String WifiManager::apSsid() const {
+  return apSsid_;
+}
+
+String WifiManager::apPassword() const {
+  return apPassword_;
+}
+
+String WifiManager::portalIp() const {
+  return apIp_.toString();
+}
+
+bool WifiManager::startApPortal() {
+  if (portalActive_) {
+    state_ = WifiState::PortalActive;
+    return true;
+  }
+
+  apSsid_ = buildApSsid();
+
+  WiFi.disconnect(false, false);
+  WiFi.mode(WIFI_AP_STA);
+  if (!WiFi.softAPConfig(apIp_, apGateway_, apSubnet_)) {
+    state_ = WifiState::ConnectFailed;
+    ZO_LOGE("Failed to configure AP IP settings");
+    return false;
+  }
+
+  const bool apStarted = WiFi.softAP(apSsid_.c_str(), apPassword_.c_str());
+  if (!apStarted) {
+    state_ = WifiState::ConnectFailed;
+    ZO_LOGE("Failed to start AP '%s'", apSsid_.c_str());
+    return false;
+  }
+
+  state_ = WifiState::ApMode;
+  if (!dnsServer_.start(kDnsPort, "*", apIp_)) {
+    ZO_LOGE("Failed to start captive DNS server");
+    portalActive_ = false;
+    return false;
+  }
+
+  dnsServer_.setErrorReplyCode(DNSReplyCode::NoError);
+  portalActive_ = true;
+  state_ = WifiState::PortalActive;
+  ZO_LOGI("Captive AP started: ssid='%s' ip=%s", apSsid_.c_str(), apIp_.toString().c_str());
+  return true;
+}
+
+void WifiManager::stopApPortal() {
+  if (!portalActive_) {
+    return;
+  }
+  dnsServer_.stop();
+  WiFi.softAPdisconnect(true);
+  portalActive_ = false;
+  ZO_LOGI("Captive AP stopped");
+}
+
+String WifiManager::buildApSsid() const {
+  String base = deviceName_;
+  if (base.isEmpty()) {
+    base = "ZivyObraz";
+  }
+
+  String chipHex = String(static_cast<uint32_t>(ESP.getEfuseMac() & 0xFFFF), HEX);
+  chipHex.toUpperCase();
+  while (chipHex.length() < 4) {
+    chipHex = "0" + chipHex;
+  }
+
+  return base + "-" + chipHex;
 }
 
 }  // namespace zivyobraz::net

--- a/src/net/wifi_manager.h
+++ b/src/net/wifi_manager.h
@@ -1,26 +1,29 @@
 #pragma once
 
 #include <Arduino.h>
+#include <DNSServer.h>
 
 #include "project_config.h"
 
 namespace zivyobraz::net {
 
 enum class WifiState : uint8_t {
-  Disconnected,
+  Unconfigured,
   Connecting,
   Connected,
-  NotConfigured,
-  ApFallback,
+  ApMode,
+  PortalActive,
+  ConnectFailed,
 };
 
 class WifiManager {
  public:
-  void begin(const WifiConfig& cfg);
+  void begin(const WifiConfig& cfg, const String& deviceName);
   void tick();
   bool connect(uint32_t timeoutMs = 15000);
   bool reconnect(uint32_t timeoutMs = 8000);
   void disconnect();
+  bool applyConfigAndConnect(const WifiConfig& cfg, uint32_t timeoutMs = 15000);
 
   WifiState state() const;
   String statusText() const;
@@ -30,10 +33,26 @@ class WifiManager {
   int32_t rssi() const;
   uint32_t apRetries() const;
   bool isConnected() const;
+  bool isPortalActive() const;
+  String apSsid() const;
+  String apPassword() const;
+  String portalIp() const;
 
  private:
+  bool startApPortal();
+  void stopApPortal();
+  String buildApSsid() const;
+
   WifiConfig cfg_{};
-  WifiState state_{WifiState::Disconnected};
+  WifiState state_{WifiState::Unconfigured};
+  String deviceName_;
+  String apSsid_;
+  String apPassword_;
+  IPAddress apIp_{192, 168, 4, 1};
+  IPAddress apGateway_{192, 168, 4, 1};
+  IPAddress apSubnet_{255, 255, 255, 0};
+  DNSServer dnsServer_;
+  bool portalActive_{false};
   uint32_t apRetries_{0};
   uint32_t lastReconnectAttemptMs_{0};
 };

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -186,6 +186,11 @@ display::StatusSnapshot Scheduler::statusSnapshot() const {
 
   s.fwVersion = config_->get().versions.fwVersion;
   s.wifiStatus = wifiDiagnostics();
+  if (wifi_ != nullptr && wifi_->isPortalActive()) {
+    s.wifiApSsid = wifi_->apSsid();
+    s.wifiPortalIp = wifi_->portalIp();
+    s.wifiApPassword = wifi_->apPassword();
+  }
   s.apiKey = config_->apiKey();
   s.serverHost = config_->get().server.host;
   s.protocolStatus = protocolDiagnostics();

--- a/src/web/web_ui.cpp
+++ b/src/web/web_ui.cpp
@@ -70,6 +70,12 @@ pre#lg{background:#161b22;border:1px solid #30363d;border-radius:4px;padding:12p
 <div id="cfg" class="tp">
 <h2>Konfigurace WiFi a serveru</h2>
 <form onsubmit="return false">
+<label>Dostupné WiFi sítě
+<select id="c-scan" style="width:100%;max-width:380px;padding:7px 10px;background:#161b22;border:1px solid #30363d;border-radius:4px;color:#c9d1d9;font-size:13px;margin-top:3px" onchange="pickScan()">
+<option value="">-- Ručně zadejte SSID nebo vyberte síť --</option>
+</select>
+</label>
+<button class="btn sec" onclick="scanWifi()" type="button" style="margin-top:8px">&#128246; Proskenovat sítě</button>
 <label>WiFi SSID<input type="text" id="c-ssid" maxlength="32" placeholder="NázevSítě"></label>
 <label>WiFi heslo (prázdné = zachovat stávající)<input type="password" id="c-pass" maxlength="64" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;"></label>
 <label>Server host<input type="text" id="c-host" maxlength="128" placeholder="cdn.zivyobraz.eu"></label>
@@ -107,7 +113,8 @@ function showTab(id,btn){
 function rfImg(){var i=document.getElementById('prev');i.src='/api/preview.bmp?_='+Date.now();}
 function loadSb(){
   fetch('/api/status').then(function(r){return r.json();}).then(function(d){
-    document.getElementById('sb').textContent='WiFi: '+d.wifi+' | IP: '+d.ip+' | RSSI: '+d.rssi+' dBm | API klíč: '+d.apiKey;
+    var mode=d.portalActive?'Konfigurační AP':'STA';
+    document.getElementById('sb').textContent='Režim: '+mode+' | WiFi: '+d.wifi+' | IP: '+d.ip+' | RSSI: '+d.rssi+' dBm | API klíč: '+d.apiKey;
   }).catch(function(){document.getElementById('sb').textContent='Nelze načíst stav';});
 }
 function loadCfg(){
@@ -118,6 +125,26 @@ function loadCfg(){
     document.getElementById('c-https').checked=!!d.httpsEnabled;
   }).catch(function(){});
 }
+
+function pickScan(){
+  var ssid=document.getElementById('c-scan').value;
+  if(ssid){document.getElementById('c-ssid').value=ssid;}
+}
+function scanWifi(){
+  fetch('/api/wifi/scan').then(function(r){return r.json();}).then(function(d){
+    if(!d.ok){showM('cm','Scan selhal: '+(d.error||''),false);return;}
+    var sel=document.getElementById('c-scan');
+    sel.innerHTML='<option value="">-- Ručně zadejte SSID nebo vyberte síť --</option>';
+    (d.networks||[]).forEach(function(n){
+      var o=document.createElement('option');
+      o.value=n.ssid;
+      o.textContent=n.ssid+' ('+n.rssi+' dBm'+(n.secure?', zabezpečeno':'')+')';
+      sel.appendChild(o);
+    });
+    showM('cm','WiFi scan dokončen, nalezeno sítí: '+((d.networks||[]).length),true);
+  }).catch(function(){showM('cm','Scan selhal (chyba komunikace)',false);});
+}
+
 function saveCfg(){
   var body='ssid='+enc(document.getElementById('c-ssid').value)
           +'&pass='+enc(document.getElementById('c-pass').value)
@@ -125,7 +152,10 @@ function saveCfg(){
           +'&https='+(document.getElementById('c-https').checked?'1':'0');
   fetch('/api/config',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:body})
   .then(function(r){return r.json();}).then(function(d){
-    showM('cm',d.ok?'Konfigurace uložena. Restartujte zařízení pro aktivaci.':'Chyba: '+(d.error||''),d.ok);
+    var msg=d.ok?'Konfigurace uložena. ':'Chyba: '+(d.error||'');
+    if(d.ok&&d.connected){msg+='WiFi připojeno, AP režim vypnut.';}
+    if(d.ok&&!d.connected){msg+='Připojení selhalo, AP režim zůstává aktivní.';}
+    showM('cm',msg,d.ok&&!!d.connected);
   }).catch(function(){showM('cm','Chyba komunikace',false);});
 }
 function showM(id,txt,ok){
@@ -191,6 +221,15 @@ void WebUI::begin(config::ConfigManager* config, net::WifiManager* wifi) {
   server_.on("/api/log", HTTP_GET, [this]() { handleApiLog(); });
   server_.on("/api/config", HTTP_POST, [this]() { handleApiConfig(); });
   server_.on("/api/restart", HTTP_POST, [this]() { handleApiRestart(); });
+  server_.on("/api/wifi/scan", HTTP_GET, [this]() { handleApiWifiScan(); });
+
+  server_.on("/generate_204", HTTP_GET, [this]() { handleGenerate204(); });      // Android
+  server_.on("/gen_204", HTTP_GET, [this]() { handleGenerate204(); });           // Android fallback
+  server_.on("/hotspot-detect.html", HTTP_GET, [this]() { handleHotspotDetect(); });  // iOS/macOS
+  server_.on("/connecttest.txt", HTTP_GET, [this]() { handleConnectTest(); });   // Windows
+  server_.on("/ncsi.txt", HTTP_GET, [this]() { handleConnectTest(); });           // Windows legacy
+
+  server_.onNotFound([this]() { handleCaptiveRedirect(); });
 
   server_.begin();
   ZO_LOGI("WebUI: HTTP server started on port 80");
@@ -231,6 +270,9 @@ void WebUI::handleApiStatus() {
   json += F(",\"ip\":\"");    json += escapeJson(wifi_->ip());           json += F("\"");
   json += F(",\"rssi\":");    json += String(wifi_->rssi());
   json += F(",\"ssid\":\"");  json += escapeJson(cfg.wifi.ssid);         json += F("\"");
+  json += F(",\"portalActive\":"); json += wifi_->isPortalActive() ? F("true") : F("false");
+  json += F(",\"apSsid\":\""); json += escapeJson(wifi_->apSsid()); json += F("\"");
+  json += F(",\"portalIp\":\""); json += escapeJson(wifi_->portalIp()); json += F("\"");
   json += F(",\"apiKey\":\""); json += escapeJson(cfg.apiKey);           json += F("\"");
   json += F(",\"host\":\"");  json += escapeJson(cfg.server.host);       json += F("\"");
   json += F(",\"httpsEnabled\":"); json += cfg.server.useHttps ? F("true") : F("false");
@@ -363,7 +405,7 @@ void WebUI::handleApiLog() {
 //   Fields: ssid, pass, host, https (0|1)
 // ---------------------------------------------------------------------------
 void WebUI::handleApiConfig() {
-  if (config_ == nullptr) {
+  if (config_ == nullptr || wifi_ == nullptr) {
     server_.send(503, "application/json", F("{\"ok\":false,\"error\":\"not ready\"}"));
     return;
   }
@@ -373,18 +415,31 @@ void WebUI::handleApiConfig() {
   const String host = server_.arg("host");
   const bool useHttps = server_.arg("https") == "1";
 
+  if (ssid.isEmpty()) {
+    server_.send(400, "application/json", F("{\"ok\":false,\"error\":\"SSID nesmi byt prazdne\"}"));
+    return;
+  }
+  if (ssid.length() > 32 || pass.length() > 64 || host.length() > 128) {
+    server_.send(400, "application/json", F("{\"ok\":false,\"error\":\"Neplatna delka vstupu\"}"));
+    return;
+  }
+
   bool wifiOk = config_->setWifi(ssid, pass);
   bool serverOk = config_->setServer(host, useHttps);
 
-  if (wifiOk && serverOk) {
-    server_.send(200, "application/json", F("{\"ok\":true}"));
-  } else if (!wifiOk && !serverOk) {
-    server_.send(200, "application/json", F("{\"ok\":false,\"error\":\"WiFi and server NVS save failed\"}"));
-  } else if (!wifiOk) {
-    server_.send(200, "application/json", F("{\"ok\":false,\"error\":\"WiFi NVS save failed\"}"));
-  } else {
-    server_.send(200, "application/json", F("{\"ok\":false,\"error\":\"Server NVS save failed\"}"));
+  if (!wifiOk || !serverOk) {
+    server_.send(500, "application/json", F("{\"ok\":false,\"error\":\"NVS save failed\"}"));
+    return;
   }
+
+  const bool connected = wifi_->applyConfigAndConnect(config_->get().wifi, 15000);
+  String json = F("{\"ok\":true,\"connected\":");
+  json += connected ? F("true") : F("false");
+  json += F(",\"portalActive\":");
+  json += wifi_->isPortalActive() ? F("true") : F("false");
+  json += F("}");
+
+  server_.send(200, "application/json", json);
 }
 
 // ---------------------------------------------------------------------------
@@ -394,6 +449,76 @@ void WebUI::handleApiRestart() {
   server_.send(200, "application/json", F("{\"ok\":true}"));
   delay(200);
   esp_restart();
+}
+
+
+void WebUI::handleApiWifiScan() {
+  if (wifi_ == nullptr) {
+    server_.send(503, "application/json", F("{\"ok\":false,\"error\":\"wifi not ready\"}"));
+    return;
+  }
+
+  const int count = WiFi.scanNetworks(false, true);
+  if (count < 0) {
+    server_.send(500, "application/json", F("{\"ok\":false,\"error\":\"scan failed\"}"));
+    return;
+  }
+
+  String json;
+  json.reserve(1024);
+  json = F("{\"ok\":true,\"networks\":[");
+  for (int i = 0; i < count; ++i) {
+    if (i > 0) {
+      json += ',';
+    }
+    json += F("{\"ssid\":\"");
+    json += escapeJson(WiFi.SSID(i));
+    json += F("\",\"rssi\":");
+    json += WiFi.RSSI(i);
+    json += F(",\"secure\":");
+    json += (WiFi.encryptionType(i) == WIFI_AUTH_OPEN) ? F("false") : F("true");
+    json += '}';
+  }
+  json += F("]}");
+
+  WiFi.scanDelete();
+  server_.send(200, "application/json", json);
+}
+
+void WebUI::handleGenerate204() {
+  if (wifi_ != nullptr && wifi_->isPortalActive()) {
+    server_.sendHeader(F("Location"), String("http://") + wifi_->portalIp() + "/", true);
+    server_.send(302, "text/plain", "");
+    return;
+  }
+  server_.send(204, "text/plain", "");
+}
+
+void WebUI::handleHotspotDetect() {
+  if (wifi_ != nullptr && wifi_->isPortalActive()) {
+    server_.sendHeader(F("Location"), String("http://") + wifi_->portalIp() + "/", true);
+    server_.send(302, "text/plain", "");
+    return;
+  }
+  server_.send(200, "text/plain", "Success");
+}
+
+void WebUI::handleConnectTest() {
+  if (wifi_ != nullptr && wifi_->isPortalActive()) {
+    server_.sendHeader(F("Location"), String("http://") + wifi_->portalIp() + "/", true);
+    server_.send(302, "text/plain", "");
+    return;
+  }
+  server_.send(200, "text/plain", "Microsoft Connect Test");
+}
+
+void WebUI::handleCaptiveRedirect() {
+  if (wifi_ != nullptr && wifi_->isPortalActive()) {
+    server_.sendHeader(F("Location"), String("http://") + wifi_->portalIp() + "/", true);
+    server_.send(302, "text/plain", "");
+    return;
+  }
+  server_.send(404, "text/plain", "Not found");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/web/web_ui.h
+++ b/src/web/web_ui.h
@@ -29,6 +29,11 @@ class WebUI {
   void handleApiLog();
   void handleApiConfig();
   void handleApiRestart();
+  void handleApiWifiScan();
+  void handleGenerate204();
+  void handleHotspotDetect();
+  void handleConnectTest();
+  void handleCaptiveRedirect();
 
   // Helpers
   static void colorIndexToRgb(uint8_t index, uint8_t& r, uint8_t& g, uint8_t& b);


### PR DESCRIPTION
### Motivation
- Provide automatic AP + captive portal fallback when STA Wi‑Fi is missing or fails so the device can be provisioned or recovered without new UI.
- Reuse the existing web UI for provisioning and show clear information on the device display to make setup straightforward.
- Keep configuration persistent and safe, and integrate provisioning into the existing Wi‑Fi management and scheduler flow.

### Description
- Implemented a new Wi‑Fi state model and captive/AP logic inside `WifiManager` with states `Unconfigured`, `Connecting`, `Connected`, `ApMode`, `PortalActive`, and `ConnectFailed`, plus `startApPortal()` / `stopApPortal()` and AP IP/ subnet handling (`src/net/wifi_manager.h`, `src/net/wifi_manager.cpp`).
- AP SSID generation now uses `boardName` + 4‑hex MAC suffix (e.g. `ZivyObraz-AB12`) and a default AP password constant `zivyobraz-setup`; captive DNS is served by `DNSServer` and processed in `tick()` while portal is active (`src/net/wifi_manager.cpp`).
- Reused and extended the existing Web UI to act as the captive portal by adding captive detection endpoints (`/generate_204`, `/gen_204`, `/hotspot-detect.html`, `/connecttest.txt`, `/ncsi.txt`), an onNotFound redirect for captive behavior, and a `GET /api/wifi/scan` endpoint for scanning SSIDs (`src/web/web_ui.h`, `src/web/web_ui.cpp`).
- Updated the config flow so `/api/config` validates input, persists via `ConfigManager::setWifi`/`setServer`, immediately attempts to apply the new Wi‑Fi config (`applyConfigAndConnect`) and returns JSON with `connected` and `portalActive` flags; the SPA was extended with a scan/select dropdown and improved feedback (`src/web/web_ui.cpp`, `src/config/config_manager.cpp`).
- Display shown in `drawStatusScreen()` now includes provisioning info (AP SSID, password, portal IP and short instructions) when portal is active; scheduler snapshot forwards AP details to the display (`src/display/st7789_display.cpp`, `src/display/display_hal.h`, `src/runtime/scheduler.cpp`).
- Minor safety/UX changes: `ConfigManager::setWifi` now validates lengths and rejects empty/oversized inputs; startup now calls `gWifi.begin(cfg.wifi, cfg.boardName)` to allow AP SSID generation (`src/config/config_manager.cpp`, `src/main.cpp`).

### Testing
- Ran static/consistency checks including `git diff --check` which reported no index issues and code was committed successfully (commit created).
- Attempted to build with `pio run` / `platformio run` in the environment but the PlatformIO CLI is not available, so a full firmware build could not be executed (failure due to missing tool).
- Attempted a headless UI check via Playwright to access `http://127.0.0.1:80`, but the device web server is not running in this environment and the probe returned `ERR_EMPTY_RESPONSE` (expected in offline environment).
- Overall: code-level validation and manual review of flows performed and no compile-time checks were possible here due to missing PlatformIO tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b295b622048322ac27155b1b276d39)