### PR TITLE
docs: split README into concise entrypoint and move detailed docs to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,423 +1,67 @@
-# Koncepce firmwaru pro ESP32 + TFT SPI klienta služby Živý obraz
+# Živý obraz LCD firmware (ESP32 + ST7789)
 
-Tento dokument navrhuje architekturu firmwaru pro zařízení s **ESP32-xxx** a **TFT displejem přes SPI**, které bude fungovat jako koncový klient služby **Živý obraz** při zachování 100% kompatibility se stávajícím serverem (historicky určeným pro ePaper firmware).
+Firmware pro ESP32 (Arduino / PlatformIO), který se periodicky připojuje k serveru Živý obraz, stahuje obrazová data a vykresluje je na TFT displej ST7789. Projekt obsahuje i lokální webové rozhraní pro konfiguraci, stav zařízení a náhled posledního framebufferu.
 
----
+Aktuálně jde o funkční základ se serverovou synchronizací, dekódováním formátů Z1/Z2/Z3 a renderem na ST7789. Některé části protokolu a roadmap položky zatím nejsou dokončené (viz omezení níže).
 
-## 1. Cíle návrhu
+## Hlavní funkce
 
-1. **Plná serverová kompatibilita**
-   - Zachovat stejný transport, endpointy, hlavičky, payload i význam odpovědí jako u původního klienta.
-   - Implementovat podporu formátů obrazu PNG/Z1/Z2/Z3 a všech řídicích HTTP hlaviček.
+- Periodický sync přes HTTP/HTTPS `POST /index.php?timestampCheck={0|1}` s hlavičkou `X-API-Key`.
+- Parsování řídicích hlaviček (`Timestamp`, `PreciseSleep`, `Rotate`, `PartialRefresh`, `ShowNoWifiError`, `X-OTA-Update`).
+- Dekódování obrazových streamů `Z1`, `Z2`, `Z3` do interního indexovaného framebufferu.
+- Render framebufferu do ST7789 (včetně rotace podle hlavičky `Rotate`).
+- Wi-Fi STA režim + fallback do captive AP portálu při chybějící/selhané konfiguraci.
+- Web UI na portu 80 (`/`, `/api/status`, `/api/config`, `/api/preview.bmp`, `/api/log`, `/api/wifi/scan`, `/api/restart`).
 
-2. **Konfigurovatelný hardware**
-   - Umožnit volbu typu desky, typu TFT kontroleru, rozlišení, barevnosti i pin-mapy bez změn serveru.
+## Architektura (high-level)
 
-3. **Webové rozhraní na zařízení**
-   - Lokální UI pro základní konfiguraci.
-   - Náhled aktuálně zobrazeného obsahu displeje (framebuffer preview).
+- `main.cpp`: boot, inicializace modulů, hlavní `loop()`.
+- `src/runtime/scheduler.*`: periodický orchestration cyklu Wi-Fi -> protocol sync -> decode -> render -> timestamp commit.
+- `src/protocol/*`: request/response kompatibilita a streamování HTTP body.
+- `src/image/*`: signaturový probe a dekódování `Z1/Z2/Z3`.
+- `src/display/*`: HAL + ST7789 backend.
+- `src/net/wifi_manager.*`: STA připojení, reconnect, AP portal a captive DNS.
+- `src/config/config_manager.*`: runtime konfigurace + perzistence v NVS (`Preferences`).
+- `src/web/web_ui.*`: SPA + REST endpointy pro správu zařízení.
 
-4. **Provozní robustnost**
-   - Bezpečné fallbacky při chybách sítě/dat.
-   - OTA aktualizace (včetně respektování serverové hlavičky `X-OTA-Update`).
+## Konfigurace
 
----
+Hlavní konfigurační oblasti:
+- Wi-Fi (`ssid`, `password`)
+- Server (`host`, `useHttps`, endpoint path)
+- Display (`width`, `height`, piny, rotace)
+- Protokol (`apiKey`, `wireDebug`, diagnostický fallback `timestampCheck=0`)
 
-## 2. Kompatibilita se serverem Živý obraz (100%)
+Výchozí hodnoty jsou v `ConfigManager::loadDefaults()` a část konfigurace je persistována do NVS.
 
-Firmware musí implementovat **stejný komunikační kontrakt** jako původní ePaper klient:
+## Getting started
 
-- HTTP/HTTPS komunikace (POST).
-- Endpoint: `POST /index.php?timestampCheck={0|1}`.
-- Hlavička `X-API-Key` jako stabilní identifikátor zařízení.
-- JSON payload se sekcemi `fwVersion`, `apiVersion`, `board`, `system`, `network`, `display` (+ volitelné senzory).
-- Zpracování hlaviček odpovědi: `Timestamp`, `PreciseSleep`, `Rotate`, `PartialRefresh`, `ShowNoWifiError`, `X-OTA-Update`.
-- Dekódování obrazového body streamu: PNG, Z1, Z2, Z3.
+1. Otevřete projekt v PlatformIO.
+2. Zkontrolujte `platformio.ini` environment `esp32dev`.
+3. Připojte ESP32 (default serial/upload 115200).
+4. Nahrajte firmware.
+5. Po startu sledujte Serial monitor.
+   - Pokud není nastavena Wi-Fi, zařízení spustí captive AP (SSID ve tvaru `<device>-<hex>`, heslo `zivyobraz-setup`).
+6. Otevřete web UI na `http://<ip-adresa-zarizeni>/` a nastavte Wi-Fi + server.
 
-> TFT klient se vůči serveru bude chovat jako drop-in náhrada: server nemusí poznat, že cílem není ePaper.
+## Build / flash / run
 
-### 2.1 Klíčové pravidlo kompatibility
+Podrobný postup je v `docs/build-and-run.md`.
 
-Síťová vrstva, payload schema a interpretační logika odpovědí budou implementovány jako samostatný modul **`protocol_compat`**, který se nemění dle typu displeje. Odlišnosti TFT/ePaper se řeší až v render vrstvě.
+## Dokumentace
 
----
+- Rozcestník: [`docs/README.md`](docs/README.md)
+- Architektura: [`docs/architecture.md`](docs/architecture.md)
+- Konfigurace: [`docs/configuration.md`](docs/configuration.md)
+- Runtime + networking: [`docs/runtime-and-networking.md`](docs/runtime-and-networking.md)
+- Web UI a API: [`docs/web-ui.md`](docs/web-ui.md)
+- Build/flash: [`docs/build-and-run.md`](docs/build-and-run.md)
+- Troubleshooting a omezení: [`docs/troubleshooting.md`](docs/troubleshooting.md)
 
-## 3. Vysoká architektura firmwaru
+## Aktuální omezení
 
-Navržená modulární struktura:
-
-1. **`core/boot`**
-   - start zařízení, init NVS, watchdog, logování, reset reason.
-
-2. **`net/wifi_manager`**
-   - STA připojení, reconnect logika, RSSI, IP stav.
-   - AP fallback (volitelně) pro prvotní konfiguraci.
-
-3. **`protocol_compat`**
-   - tvorba requestů (hlavičky + JSON metadata),
-   - parsování odpovědí a řídicích hlaviček,
-   - timestamp rozhodovací logika,
-   - retry/timeout policy.
-
-4. **`image_decoder`**
-   - detekce signatury streamu,
-   - dekódování PNG/Z1/Z2/Z3 do interního framebufferu,
-   - toleranční režim při částečně poškozeném streamu.
-
-5. **`display_hal`**
-   - abstrakce nad TFT knihovnou/driverem,
-   - převod palety barev Živý obraz -> fyzické barvy panelu,
-   - push framebufferu přes SPI,
-   - rotace, orientace, případné „partial refresh“ mapované jako dirty regions.
-
-6. **`config_manager`**
-   - perzistence konfigurace v NVS,
-   - validace hodnot,
-   - schema verzování konfigurace.
-
-7. **`web_ui`**
-   - HTTP server na zařízení,
-   - stránky pro konfiguraci,
-   - endpointy pro náhled framebufferu,
-   - základní diagnostika.
-
-8. **`ota_manager`**
-   - lokální OTA (upload firmware),
-   - vzdálená OTA přes URL z `X-OTA-Update`.
-
-9. **`scheduler/power`**
-   - plánování cyklu fetch-render-sleep,
-   - respektování `PreciseSleep`,
-   - light/deep sleep strategie dle typu zařízení.
-
----
-
-## 4. Datový tok (runtime)
-
-1. Boot + načtení konfigurace.
-2. Připojení k Wi-Fi.
-3. Odeslání `timestampCheck=1` requestu.
-4. Parsování hlaviček:
-   - pokud stejný `Timestamp` => bez refresh, přejít do sleep dle `PreciseSleep`.
-   - pokud nový `Timestamp` => stáhnout/načíst obrazová data (podle zvoleného režimu 1- nebo 2-fázově).
-5. Dekódování PNG/Z1/Z2/Z3 do framebufferu.
-6. Render na TFT přes SPI.
-7. Uložení runtime metrik (`lastDownloadDuration`, `lastRefreshDuration`) pro další request.
-8. Sleep a opakování.
-
----
-
-## 5. Konfigurace desky a displeje
-
-Konfigurace bude rozdělena na:
-
-### 5.1 Build-time profil (volitelné)
-
-- `board_profile` (např. esp32dev, esp32-s3, custom),
-- výchozí pinout SPI,
-- výchozí driver displeje.
-
-Výhoda: rychlá kompilace připravených variant.
-
-### 5.2 Runtime konfigurace (NVS + Web UI)
-
-Povinné položky:
-
-- **Deska**: model MCU/board profilu.
-- **Displej**:
-  - řadič (např. ILI9341/ST7789/GC9A01),
-  - šířka, výška,
-  - orientace/rotace,
-  - barevný režim (interně mapovaný na `BW|3C|GRAYSCALE|7C` pro serverový payload).
-- **SPI parametry**:
-  - piny MOSI/SCLK/CS/DC/RST/BL,
-  - frekvence SPI,
-  - invertace barev (pokud panel vyžaduje).
-- **Síť**:
-  - SSID, heslo,
-  - server host (default `cdn.zivyobraz.eu`),
-  - HTTP/HTTPS mód.
-
-### 5.3 Validace konfigurace
-
-- kontrola konfliktů pinů,
-- kontrola rozsahů rozlišení,
-- test inicializace displeje při uložení,
-- rollback na poslední funkční konfiguraci při boot failu.
-
----
-
-## 6. Webové rozhraní na desce
-
-Minimální web UI (SPA nebo jednoduché server-rendered stránky):
-
-1. **Dashboard**
-   - stav Wi-Fi, IP, RSSI,
-   - API key,
-   - poslední timestamp,
-   - poslední časy download/refresh,
-   - uptime, reset reason.
-
-2. **Konfigurace**
-   - síťové parametry,
-   - board/display/SPI konfigurace,
-   - intervaly a provozní volby.
-
-3. **Náhled displeje**
-   - endpoint `/preview` vracející JPEG/PNG z interního framebufferu,
-   - endpoint `/preview/live` (periodické obnovování),
-   - volitelně překryv diagnostiky (FPS renderu, velikost posledního payloadu).
-
-4. **Servis**
-   - restart,
-   - factory reset konfigurace,
-   - OTA upload.
-
-### 6.1 Bezpečnost web UI
-
-- výchozí AP provisioning režim chráněný heslem,
-- v STA režimu volitelná HTTP Basic Auth,
-- CSRF token pro POST operace,
-- možnost úplně vypnout web UI po dokončení instalace.
-
----
-
-## 7. Render strategie pro TFT
-
-Aby byla zachována kompatibilita se serverem, ale zároveň efektivní provoz na TFT:
-
-- interní framebuffer bude mít logické barvy služby Živý obraz (indexy 0..6),
-- render backend převede indexové barvy do RGB565 dle konkrétního panelu,
-- `Rotate` hlavička se aplikuje před push na displej,
-- `PartialRefresh` se interpretuje jako preferovaný režim aktualizace dirty regions (když HW/driver umí).
-
-Pozn.: Oproti ePaper není nutná stejná fyzická semantika partial refresh; důležité je, aby vizuální výsledek odpovídal dodanému obrazu.
-
----
-
-## 8. Spolehlivost a provoz
-
-- Retry připojení k serveru minimálně 3x.
-- Timeouty kompatibilní s původním klientem.
-- Tolerance rušivých dat před signaturou obrázku (scan prvních 4 KB).
-- Watchdog pro síťové i render operace.
-- Ring buffer logů dostupný přes web UI.
-
----
-
-## 9. Doporučená implementační roadmapa
-
-### Fáze 1: Kompatibilní síťové jádro
-- Implementovat `protocol_compat` a validovat proti test serveru.
-- Ověřit hlavičky, timestamp logiku, sleep intervaly.
-
-### Fáze 2: Decoder + TFT render
-- Přidat PNG/Z1/Z2/Z3 dekodéry.
-- Integrace s jedním referenčním TFT (např. ST7789).
-
-### Fáze 3: Konfigurace + Web UI
-- NVS schema, validační pravidla.
-- UI stránky + preview endpoint.
-
-### Fáze 4: Multi-board/multi-display
-- Rozšířit driver tabulky o další kontrolery.
-- Profilový systém a kompatibilitní test matrix.
-
-### Fáze 5: Produkční hardening
-- OTA, autentizace UI, burn-in testy, telemetrie chyb.
-
----
-
-## 10. Testovací strategie
-
-1. **Protokolová kompatibilita**
-   - golden testy HTTP request/response vůči referenčním dumpům.
-2. **Dekódování formátů**
-   - unit testy pro PNG/Z1/Z2/Z3 na známých vzorcích.
-3. **Render korektnost**
-   - porovnání referenčního framebufferu a screenshotu displeje.
-4. **Konfigurace**
-   - validační testy NVS schématu a migration testy.
-5. **End-to-end**
-   - scénáře „nový timestamp“, „stejný timestamp“, „server error“, „OTA trigger“.
-
----
-
-## 11. Shrnutí
-
-Navržený firmware odděluje **serverově-kompatibilní komunikační vrstvu** od **hardware-specifické render vrstvy TFT**. Tím je možné zachovat 100% zpětnou kompatibilitu se službou Živý obraz, a současně nabídnout moderní správu zařízení přes vestavěné webové rozhraní, včetně náhledu aktuálního obsahu displeje a konfigurace desky/displeje.
-
----
-
-## 10. Firmware scaffold (PlatformIO, ESP32 DevKit + ST7789) - Phase 1 baseline
-
-Tento repozitář nyní obsahuje inicializační firmware scaffold v C++ pro PlatformIO (`esp32dev`, Arduino framework), připravený pro postupné doplnění plné kompatibility se serverovým protokolem Živý obraz.
-
-### Aktuální účel
-
-- Spustitelný základ s jasně oddělenými vrstvami:
-  - boot/core
-  - config manager
-  - wifi manager
-  - protocol compatibility facade
-  - image decoder interface
-  - display HAL (ST7789)
-  - runtime scheduler
-  - diagnostics
-- Po flashnutí se inicializuje Serial i ST7789, vykreslí se diagnostická obrazovka a periodicky běží scheduler tick.
-
-### Struktura modulů
-
-- `src/core` - start systému, boot banner, reset reason helper.
-- `src/config` - runtime konfigurace a výchozí nastavení pro `esp32dev + ST7789 240x240`.
-- `src/net` - Wi-Fi manager abstraction (zatím compile-safe stub).
-- `src/protocol` - modely request/response + scaffold pro server kompatibilní tok.
-- `src/image` - detekce formátu + decoder rozhraní pro PNG/Z1/Z2/Z3.
-- `src/display` - display HAL a ST7789 backend, status screen + test primitives.
-- `src/runtime` - jednoduchý periodický state machine připravený pro fetch-render-sleep.
-- `src/diagnostics` - log makra, systémové info helpery a kruhový log buffer pro web UI.
-- `src/web` - vestavěný HTTP server (port 80) s webovým rozhraním (4 záložky).
-
-### Doporučené další kroky
-
-1. Implementovat reálný HTTPS POST flow (`X-API-Key`, `/index.php?timestampCheck=`) v `protocol_compat`.
-2. Doplnit parsování odpovědních hlaviček (`Timestamp`, `PreciseSleep`, `Rotate`, `PartialRefresh`, `ShowNoWifiError`, `X-OTA-Update`).
-3. Napojit HTTP body stream na `image_decoder` facade.
-4. Implementovat reálné dekodéry PNG/Z1/Z2/Z3 do `PixelSink`.
-5. Přidat NVS perzistenci do `config_manager` a STA/AP fallback režimy ve `wifi_manager`.
-6. Rozšířit scheduler o řízený fetch-render-sleep cyklus včetně deep sleep strategie.
-
-## 11. Milestone update: stream decode + indexed framebuffer render (current step)
-
-Nově je implementováno:
-
-- Streamové předání HTTP body z `protocol_compat` do dekódovací pipeline přes `HttpBodyStream` bez ukládání celého payloadu do velkého `String` bufferu.
-- Tolerantní signaturový probe (okno až 4096 B) pro `PNG`, `Z1`, `Z2`, `Z3` v `image_decoder` s reportem formátu i offsetu signatury.
-- Interní `IndexedFramebuffer` (`uint8_t` indexy, contiguous storage, bounds-checked access) nezávislý na ST7789 driveru.
-- Dekódování formátů `Z1`, `Z2`, `Z3` do interního framebufferu (row-major), včetně robustního hlášení chyb:
-  - truncated stream
-  - zero-length run
-  - unsupported color index
-  - pixel overflow
-- `PNG` je nyní korektně rozpoznáno a vrací stav „recognized but not implemented yet“.
-- Render cesta z indexového framebufferu do ST7789:
-  - deterministické mapování barev 0..6 -> RGB565
-  - aplikace `Rotate` až ve fázi renderu
-  - `PartialRefresh` je propisováno jako hint (TODO pro další optimalizace)
-- Timestamp commit policy v scheduleru:
-  - beze změny timestampu: bez decode/render/commit
-  - při chybě decode/render: bez commit
-  - commit do NVS pouze po úspěšném decode + render
-- Rozšířená diagnostická obrazovka: Wi-Fi, API key, host, protocol status, detected format, signature offset, decode result, decoded pixels, stored/candidate timestamp, render result.
-
-### Aktuální omezení
-
-- PNG dekodér není implementován (jen detekce + explicitní stav).
-- OTA download/execution, deep sleep politika, AP provisioning a web UI nejsou v tomto kroku implementovány.
-- Render běží jako full redraw (bez dirty-region optimalizace).
-
-### Přesně doporučený další krok
-
-1. Přidat PNG dekodér do stejného `ImageDecoderFacade` kontraktu.
-2. Po stabilizaci PNG doplnit sleep policy (`PreciseSleep` + deep sleep) a navázat partial refresh optimalizace v render backendu.
-3. Následně řešit OTA execution flow s bezpečným rollbackem.
-
-## 12. Milestone update: protocol wire diagnostics + missing Timestamp classification
-
-V tomto kroku byla doplněna cílená diagnostika protokolu (bez uvolnění produkčních pravidel):
-
-- Přidán debug přepínač `PROTOCOL_WIRE_DEBUG` (build flag) / runtime `protocolDebug.wireDebug` pro zapnutí detailních wire logů.
-- V debug režimu firmware loguje:
-  - raw HTTP status line,
-  - raw response headers (řádek po řádku),
-  - parsed interpretaci známých hlaviček,
-  - počet hlaviček a detekci oddělovače header/body,
-  - request payload JSON + host/path/transport/content-length/API key/`timestampCheck`.
-- Přidán bezpečný body preview (max 256 B) v HEX + ASCII a diagnostická klasifikace signatury (`PNG`, `Z1`, `Z2`, `Z3`, `HTML`, `text`, `unknown`) včetně offsetu.
-- Stav `HTTP 200 + body + chybějící Timestamp` je nově explicitně klasifikován jako protokolová nekompatibilita (`missing_ts`), nikoli jako běžný no-change scénář.
-- Debug-only probe při chybějícím `Timestamp` je ne-destruktivní: necommituje timestamp a nezměkčuje produkční rozhodnutí.
-- Přidán volitelný diagnostický fallback mód: po `timestampCheck=1` odpovědi bez `Timestamp` lze vynutit následující cyklus s `timestampCheck=0` (`forceTimestampCheckZeroOnMissingTimestamp`).
-- Diagnostická obrazovka zobrazuje navíc: protocol debug on/off, protokolovou klasifikaci, missing Timestamp flag, body probe klasifikaci a offset.
-
-### Pravděpodobný další krok
-
-Porovnat skutečný wire dump (raw status/headers/body preview) s očekávaným serverovým kontraktem a potvrdit, zda problém vzniká na straně serverové odpovědi nebo ve formátu hlaviček/flow režimu `timestampCheck`.
-
-## 13. Milestone update: request schema hardening + API key preflight
-
-V tomto kroku byl zpřísněn request kontrakt směrem k serverovému protokolu:
-
-- Payload `board` je nyní posílán jako skalární string (ne jako objekt).
-- `network.ip` byl nahrazen `network.ipAddress` a payload obsahuje i `network.apRetries`.
-- `display` metadata jsou rozšířena na `type`, `width`, `height`, `colorType` (pro ST7789 nyní `"7C"`).
-- `system` již neposílá nekompatibilní `name`; posílají se jen protokolově kompatibilní pole (aktuálně `resetReason`, pokud je k dispozici).
-- API key lifecycle byl zpřesněn:
-  - validace přesně 8 číslic,
-  - při chybě/missing stavu regenerace + persistence,
-  - jasné logování, zda byl key načten nebo regenerován.
-- Přidána preflight validace requestu před odesláním (`apiKey`, `board`, `network.ipAddress`, `display.width/height/colorType`).
-  - Při validační chybě se request neodešle.
-- Wire debug log nově obsahuje kompaktní schema summary (`boardKind`, `systemFields`, `networkFields`, `displayFields`, `apiKeyValid`).
-
----
-
-## 14. Milestone update: webové rozhraní (Živý obraz / Konfigurace / Správa / Debug)
-
-Nově je implementováno kompletní vestavěné webové rozhraní (`src/web/web_ui.h`, `src/web/web_ui.cpp`) běžící na portu **80** přímo v ESP32 HTTP serveru (Arduino `WebServer`).
-
-### Záložky webového rozhraní
-
-| Záložka | URL fragment | Popis |
-|---------|-------------|-------|
-| 📷 **Živý obraz** | `#live` | Náhled aktuálního obrazu zobrazeného na LCD (BMP, automaticky se obnovuje každých 30 s) |
-| ⚙️ **Konfigurace** | `#cfg` | Editace WiFi SSID/hesla, adresy serveru a HTTPS přepínače; změny jsou okamžitě uloženy do NVS |
-| 🔧 **Správa** | `#adm` | Přehled verzí FW/API, čip, flash, SDK, uptime, volná RAM; tlačítko restart |
-| 🐛 **Debug** | `#dbg` | Real-time výpis všech log zpráv (polling 1 s); zachovává i výstup na sériový port |
-
-### HTTP API endpointy
-
-| Metoda | Endpoint | Popis |
-|--------|----------|-------|
-| `GET` | `/` | SPA HTML stránka |
-| `GET` | `/api/status` | JSON se stavem WiFi, IP, RSSI, konfigurací, systémovými informacemi |
-| `GET` | `/api/preview.bmp` | Aktuální obraz jako 8bpp Windows BMP (velikost závisí na rozlišení displeje) |
-| `GET` | `/api/log?since=N` | JSON `{ "lines": [...], "next": N }` s novými log řádky od indexu N |
-| `POST` | `/api/config` | Uloží konfiguraci WiFi/server (`application/x-www-form-urlencoded`) |
-| `POST` | `/api/restart` | Restartuje zařízení |
-
-### Přístup k rozhraní
-
-Po připojení zařízení do WiFi otevřete v prohlížeči:
-
-```
-http://<IP_ADRESA_ZARIZENI>/
-```
-
-IP adresu zařízení zjistíte na LCD diagnostické obrazovce nebo ze sériového portu (115 200 Bd).
-
-### Screenshot webového rozhraní
-
-```
-┌────────────────────────────────────────────────────────────────┐
-│ 📺 Živý obraz – LCD panel                                      │
-├────────────────────────────────────────────────────────────────┤
-│ WiFi: connected | IP: 192.168.1.42 | RSSI: -67 dBm | API: ... │
-├──────────┬──────────────┬──────────┬──────────────────────────┤
-│📷Živý ob.│⚙️Konfigurace │🔧Správa  │🐛Debug                   │
-├──────────┴──────────────┴──────────┴──────────────────────────┤
-│                                                                │
-│         [  aktuální obraz z LCD 240×240 px  ]                 │
-│                                                                │
-│                    [ 🔄 Obnovit nyní ]                        │
-└────────────────────────────────────────────────────────────────┘
-```
-
-> Skutečný screenshot je dostupný v prohlížeči po připojení k běžícímu zařízení na `http://<IP>/`.
-
-### Technické detaily implementace
-
-- **`src/web/web_ui.h` / `web_ui.cpp`** – třída `WebUI` (ESP32 Arduino `WebServer` na portu 80).
-- **`src/diagnostics/log_buffer.h` / `log_buffer.cpp`** – kruhový buffer posledních 100 log řádků; `gLogBuffer` je globální singleton dostupný z log makra.
-- **`src/diagnostics/log.h` / `log.cpp`** – log makra nyní zapisují do Serialu **i** do kruhového bufferu; sériový výstup je beze změny.
-- Náhled obrazu (`/api/preview.bmp`) je generován jako 8bpp Windows BMP přímo z posledního `IndexedFramebuffer` (volá `Scheduler::tick()` po každém úspěšném renderu přes `WebUI::updatePreview()`).
-- Konfigurace WiFi a serveru uložená přes web UI se projeví po restartu zařízení.
+- PNG je rozpoznán, ale není implementován dekodér.
+- `PreciseSleep` je parsován, ale scheduler aktuálně běží na fixním intervalu 90 s.
+- `PartialRefresh` je předán do renderu jen jako hint; optimalizovaný partial render není implementován.
+- OTA flow není implementován (`ZO_FEATURE_OTA=0`; hlavička `X-OTA-Update` se jen čte).
+- `lastTimestamp` se při bootu nenačítá z NVS (po restartu se vždy začíná novou synchronizací).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Dokumentace projektu
+
+Tato složka obsahuje podrobnou technickou dokumentaci k firmware.
+
+## Obsah
+
+- [`architecture.md`](architecture.md) - architektura, entry point, moduly a odpovědnosti.
+- [`configuration.md`](configuration.md) - konfigurační model, výchozí hodnoty, NVS perzistence.
+- [`runtime-and-networking.md`](runtime-and-networking.md) - boot/runtime flow, scheduler, Wi-Fi a serverový sync.
+- [`web-ui.md`](web-ui.md) - vestavěné webové rozhraní a endpointy.
+- [`build-and-run.md`](build-and-run.md) - build/flash/monitor workflow (PlatformIO).
+- [`troubleshooting.md`](troubleshooting.md) - ověřená omezení a diagnostické tipy.
+
+## Poznámka ke zdrojům pravdy
+
+Popis je založen na aktuální implementaci ve `src/` a `include/`, ne na historických návrzích.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,59 @@
+# Architektura
+
+## Entry point
+
+- Firmware vstupuje přes `setup()` a `loop()` v `src/main.cpp`.
+- `setup()` inicializuje: serial, config manager, Wi-Fi manager, protocol service, display, scheduler a web UI.
+- `loop()` volá `Scheduler::tick()`, `WebUI::tick()` a periodicky vykreslí status screen, pokud zatím není validní obraz.
+
+## Modulární rozdělení
+
+### Core
+- `src/core/boot.*`
+- Inicializace serial linky a boot log banneru (FW/API/build/chip/reset reason).
+
+### Configuration
+- `src/config/config_manager.*`
+- Správa runtime konfigurace (`RuntimeConfig`) a perzistence přes `Preferences` (NVS namespace `zo_cfg`).
+- Generuje/validuje 8místný numerický API klíč.
+
+### Networking
+- `src/net/wifi_manager.*`
+- STA připojení + reconnect logika.
+- Fallback do AP+STA režimu s captive DNS (`DNSServer`) při chybějícím SSID nebo neúspěšném connectu.
+
+### Protocol compatibility
+- `src/protocol/protocol_compat.*`, `src/protocol/protocol_models.h`, `src/protocol/http_body_stream.*`
+- Staví JSON metadata payload, odesílá HTTP/HTTPS POST, parsuje status line + hlavičky.
+- Předává body stream callbacku pro dekodér bez plného bufferování payloadu.
+
+### Image pipeline
+- `src/image/image_decoder.*`, `src/image/indexed_framebuffer.*`
+- Signaturový probe (`PNG/Z1/Z2/Z3`) v okně `probeLimit`.
+- Dekódování `Z1/Z2/Z3` do `IndexedFramebuffer`.
+
+### Display
+- `src/display/display_hal.h`, `src/display/st7789_display.*`
+- HAL rozhraní + ST7789 implementace přes Adafruit ST7789/GFX.
+- Render indexovaných barev (0..6) na RGB565 a mapování souřadnic podle rotace.
+
+### Runtime orchestrace
+- `src/runtime/scheduler.*`
+- Tick-based state machine (interval 90 s), koordinuje sync/decode/render, rozhoduje o commitu timestampu.
+
+### Diagnostics
+- `src/diagnostics/*`
+- Log makra do serialu + ring bufferu pro web debug.
+- Systémové informace (chip/flash/SDK).
+
+### Web UI
+- `src/web/web_ui.*`
+- HTTP server (port 80), SPA stránka + API endpointy pro status, konfiguraci, preview, logy a restart.
+
+## Datový tok (aktuální implementace)
+
+1. Scheduler při ticku ověří Wi-Fi stav.
+2. Při aktivním spojení zavolá `ProtocolCompatService::performSync(...)`.
+3. Body callback dekóduje image stream do framebufferu.
+4. Při úspěchu se renderuje do display backendu.
+5. Timestamp se uloží do konfigurace pouze při úspěšném decode+render scénáři pro změněný obsah.

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -1,0 +1,36 @@
+# Build, flash a spuštění
+
+## Požadavky
+
+- PlatformIO (CLI nebo VS Code extension)
+- ESP32 deska kompatibilní s `board = esp32dev`
+- ST7789 připojený dle pinů z výchozí konfigurace nebo vlastního nastavení
+
+## PlatformIO konfigurace
+
+`platformio.ini` obsahuje jeden environment:
+- `[env:esp32dev]`
+- framework: Arduino
+- knihovny: `Adafruit GFX`, `Adafruit ST7735 and ST7789`
+- C++17
+
+## Typický workflow
+
+```bash
+platformio run
+platformio run -t upload
+platformio device monitor -b 115200
+```
+
+## Zprovoznění zařízení
+
+1. Flash firmware.
+2. Otevřít serial monitor (`115200`).
+3. Pokud není STA konfigurace, zařízení spustí AP portal.
+4. Otevřít `http://<ip>` (v AP režimu typicky `http://192.168.4.1/`).
+5. Nastavit SSID/heslo a server host + HTTPS.
+6. Po úspěšném připojení běží periodický sync přes scheduler.
+
+## Poznámka k tomuto repozitáři
+
+V tomto prostředí nebylo možné ověřit build příkazem `platformio run`, protože `platformio` binárka není nainstalována.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,42 @@
+# Konfigurace
+
+## RuntimeConfig struktura
+
+Definice je v `include/project_config.h`:
+- `boardName`
+- `display` (`type`, `width`, `height`, `pins`, `rotation`)
+- `wifi` (`ssid`, `password`)
+- `server` (`host`, `useHttps`, `endpointPath`)
+- `versions` (`fwVersion`, `apiVersion`)
+- `apiKey`
+- `lastTimestamp`
+- `protocolDebug` (`wireDebug`, `forceTimestampCheckZeroOnMissingTimestamp`)
+
+## Výchozí hodnoty
+
+Nastavuje `ConfigManager::loadDefaults()`:
+- board: `esp32dev`
+- display: ST7789, 240x240, rotace 0, výchozí SPI pinout (MOSI 23, SCLK 18, DC 16, RST 17, BL 4, CS -1)
+- server: `cdn.zivyobraz.eu`, HTTPS zapnuto, path `/index.php`
+- Wi-Fi: prázdné SSID/password
+- API key: při startu validace; pokud chybí/invalid, vygeneruje se nový 8-digit key
+
+## NVS perzistence
+
+Ukládá se namespace `zo_cfg`, klíče:
+- `wifi_ssid`, `wifi_pass`, `host`, `https`, `api_key`, `last_ts`
+
+## Důležité chování
+
+- `lastTimestamp` se z NVS při `load()` záměrně nenačítá.
+- `setWifi()` vyžaduje neprázdné SSID; prázdné heslo znamená „ponechat stávající“.
+- `setServer()` ponechá původní host, pokud je nový host prázdný.
+
+## Build-time přepínače
+
+`platformio.ini` definuje:
+- `ZO_FW_VERSION`, `ZO_API_VERSION`, `ZO_BUILD_DATE`
+- feature flagy (`ZO_FEATURE_WIFI`, `ZO_FEATURE_HTTPS`, `ZO_FEATURE_OTA`)
+- `PROTOCOL_WIRE_DEBUG`
+
+`PROTOCOL_WIRE_DEBUG=1` zapíná wire debug default už v konfiguraci.

--- a/docs/runtime-and-networking.md
+++ b/docs/runtime-and-networking.md
@@ -1,0 +1,66 @@
+# Runtime a networking flow
+
+## Boot a hlavní smyčka
+
+- `setup()` inicializuje moduly v pořadí: serial -> config -> wifi -> protocol -> display -> scheduler -> web UI.
+- Scheduler provede při startu i okamžitý pokus o Wi-Fi connect.
+- `loop()` volá scheduler a web server tick, plus fallback status screen.
+
+## Scheduler
+
+- Tick interval je pevný: `kTickIntervalMs = 90000` (90 s).
+- Při každém ticku:
+  1. aktualizace Wi-Fi stavu,
+  2. pokud není Wi-Fi connected: sync se přeskočí,
+  3. pokud je connected: spustí se protocol sync + decode/render callback,
+  4. podle výsledku se rozhodne o `lastTimestamp` commitu.
+
+### Timestamp commit policy
+
+- `SuccessChanged` + `bodyPresent` + `decode.success` + `renderSuccess` -> timestamp se uloží.
+- Při decode/render chybě nebo chybějícím body se timestamp neukládá.
+- `SuccessUnchanged` bez body -> render skip.
+
+## Wi-Fi flow
+
+`WifiManager`:
+- Pokud je SSID prázdné: přechod do captive AP režimu.
+- Pokud STA connect selže: fallback do captive AP.
+- AP režim používá:
+  - SSID `<deviceName>-<last4hex>`
+  - heslo `zivyobraz-setup`
+  - IP `192.168.4.1`
+  - DNS wildcard redirect přes `DNSServer`
+- Reconnect pokusy běží periodicky (`kReconnectIntervalMs = 10000`).
+
+## Protocol sync
+
+`ProtocolCompatService::performSync(...)`:
+- Vyžaduje aktivní Wi-Fi.
+- Validuje request metadata a API key.
+- Odesílá `POST` na `<endpointPath>?timestampCheck=...`.
+- Hlavičky requestu: `Host`, `X-API-Key`, `Content-Type: application/json`, `Content-Length`.
+- Pro HTTPS používá `WiFiClientSecure::setInsecure()`.
+
+### Parsované response hlavičky
+
+- `Timestamp`
+- `PreciseSleep`
+- `Rotate`
+- `PartialRefresh`
+- `ShowNoWifiError`
+- `X-OTA-Update`
+
+### Diagnostika a klasifikace
+
+- Podporován wire debug log (raw status line, raw headers, payload summary, body preview).
+- `HTTP 200 + body + missing Timestamp` je explicitní protocol error (`missing_ts`).
+- Volitelný diagnostický fallback: jednorázové `timestampCheck=0` po chybějícím timestampu.
+
+## Decode + render
+
+- Probe signatury až do limitu 4096 B (`kProbeLimit`).
+- Podporované dekódy: `Z1`, `Z2`, `Z3`.
+- `PNG` je rozpoznán, ale vrací `RecognizedNotImplemented`.
+- Render path: indexovaný framebuffer -> ST7789 backend (`renderIndexed`).
+- `PartialRefresh` je aktuálně pouze logovaný hint.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting a známá omezení
+
+## Známá omezení (ověřeno v kódu)
+
+1. PNG není dekódován
+   - Signatura PNG je detekována, ale dekodér vrací stav „recognized but not implemented yet“.
+
+2. PreciseSleep není použit pro plánování
+   - `PreciseSleep` je parsován z hlavičky, ale scheduler používá fixní interval 90 s.
+
+3. OTA není implementováno
+   - Přítomnost `X-OTA-Update` se eviduje, ale není žádný download/flash OTA flow.
+
+4. Partial refresh není optimalizován
+   - `partialRefresh` se předává do renderu jako hint, ale render běží full redraw.
+
+5. HTTPS certifikáty nejsou validovány
+   - `WiFiClientSecure` používá `setInsecure()`.
+
+6. `lastTimestamp` není obnovován po restartu
+   - Config manager jej při `load()` z NVS nenačítá.
+
+## Diagnostické body
+
+- Serial log: obsahuje boot banner, Wi-Fi stav, HTTP status a decode/render výsledky.
+- Web Debug tab: čte logy z ring bufferu (`/api/log`).
+- Protocol wire debug:
+  - build flag `PROTOCOL_WIRE_DEBUG=1` nebo runtime `protocolDebug.wireDebug`
+  - zobrazí raw status line, headers a body preview.
+
+## Časté problémy
+
+- **Zařízení se nepřipojí do Wi-Fi:**
+  - Ověřte SSID/heslo přes web konfiguraci.
+  - Pokud connect selhává, zařízení zůstane v AP portálovém režimu.
+
+- **Server vrací HTTP 200, ale bez aktualizace:**
+  - Zkontrolujte, zda je přítomen `Timestamp` header.
+  - Při missing timestampu je odpověď klasifikována jako protokolová nekompatibilita.
+
+- **Preview není dostupný (`404 No preview available yet`):**
+  - Preview se naplní až po prvním úspěšném decode+render cyklu.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,36 @@
+# Web UI a HTTP API
+
+## Přehled
+
+`WebUI` startuje `WebServer` na portu 80 a poskytuje SPA stránku i API endpointy.
+
+## UI záložky
+
+- Živý obraz (náhled z `/api/preview.bmp`)
+- Konfigurace (Wi-Fi + server)
+- Správa (stav zařízení + restart)
+- Debug (stream logů z ring bufferu)
+
+## Endpointy
+
+- `GET /` - HTML SPA
+- `GET /api/status` - JSON stav (Wi-Fi, IP, RSSI, host, verze, systémové info)
+- `GET /api/preview.bmp` - 8bpp BMP z posledního framebufferu
+- `GET /api/log?since=N` - inkrementální log stream
+- `POST /api/config` - uloží Wi-Fi/server config, následně zkusí reconnect
+- `POST /api/restart` - restart zařízení
+- `GET /api/wifi/scan` - scan dostupných sítí
+
+## Captive portal routy
+
+Pro klientské OS test URL:
+- `/generate_204`, `/gen_204` (Android)
+- `/hotspot-detect.html` (iOS/macOS)
+- `/connecttest.txt`, `/ncsi.txt` (Windows)
+- ostatní požadavky jdou přes `onNotFound()` do captive redirectu při aktivním portálu.
+
+## Preview formát
+
+- Endpoint vrací BMP (`image/bmp`) generovaný za běhu.
+- Palette má 8 definovaných barev (indexy 0..7), zbytek 256-entry tabulky je nulový.
+- Zdroj dat je poslední framebuffer předaný schedulerem po úspěšném renderu.


### PR DESCRIPTION
### Motivation
- Reduce an oversized, planning-heavy README into a short, practical project entrypoint and move detailed technical content into a structured `docs/` tree. 
- Ensure all documentation statements are accurate by verifying them against the current implementation in `src/` and `include/` and surface known limitations instead of guessing.

### Description
- Rewrote main `README.md` as a concise onboarding document describing purpose, main features, high-level architecture, basic configuration and a short getting-started section. 
- Added a `docs/` directory with topic-based, implementation-aligned files: `docs/README.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/runtime-and-networking.md`, `docs/web-ui.md`, `docs/build-and-run.md`, and `docs/troubleshooting.md`. 
- Updated documentation to reflect the actual implementation (entry point, scheduler flow, protocol handling, supported image formats Z1/Z2/Z3, ST7789 render path, web UI endpoints, NVS keys, and config defaults) and explicitly documented current limitations (PNG decoder not implemented, fixed 90s scheduler tick, OTA/partial-refresh not implemented, `WiFiClientSecure::setInsecure()`, `lastTimestamp` not restored on boot). 
- Kept implementation unchanged; this PR only restructures and clarifies documentation to match the codebase.

### Testing
- Ran a whitespace/lint check via `git diff --check` which reported no issues (success). 
- Verified presence and expected headings in `README.md` and `docs/README.md` using a simple search (`rg "^#" README.md docs/README.md`) (success).
- Attempted to run `platformio run` to validate a build, but the `platformio` CLI is not available in this environment so the build could not be executed (command failed with `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a80482ac8322847a8dcfe53acd23)